### PR TITLE
Persistent state filter options

### DIFF
--- a/app/web/src/context/ApplicationProvider.tsx
+++ b/app/web/src/context/ApplicationProvider.tsx
@@ -11,6 +11,19 @@ let metricsInterval;
 let metadataInterval;
 const workerStates = ["HEARTBEAT", "ONLINE", "OFFLINE"];
 
+const tasksStatesDefaults = [
+    {key: "QUEUED", doc_count: 0},
+    {key: "RECEIVED", doc_count: 0},
+    {key: "STARTED", doc_count: 0},
+    {key: "SUCCEEDED", doc_count: 0},
+    {key: "FAILED", doc_count: 0},
+    {key: "REJECTED", doc_count: 0},
+    {key: "REVOKED", doc_count: 0},
+    {key: "RETRY", doc_count: 0},
+    {key: "RECOVERED", doc_count: 0},
+    {key: "CRITICAL", doc_count: 0},
+];
+
 interface ApplicationContextData {
     applications: {
         app_name: string,
@@ -74,7 +87,7 @@ const initial = {
     processedEvents: 0,
     processedTasks: 0,
     seenStates: [],
-    seenTaskStates: [],
+    seenTaskStates: tasksStatesDefaults,
     seenRoutingKeys: [],
     seenQueues: [],
     seenEnvs: []
@@ -140,10 +153,10 @@ function ApplicationProvider({children}) {
                 setSeenWorkers(result.aggregations.seen_workers.buckets);
                 setSeenTasks(result.aggregations.seen_tasks.buckets);
                 setSeenStates(result.aggregations.seen_states.buckets);
-                setSeenTaskStates(
-                    result.aggregations.seen_states.buckets.filter(
-                        item => !workerStates.includes(item.key)
-                    )
+                setSeenTaskStates(tasksStatesDefaults
+                    .map(obj => result.aggregations.seen_states.buckets
+                        .find(o => o.key === obj.key) || obj)
+                    .filter(item => !workerStates.includes(item.key))
                 );
                 setSeenRoutingKeys(result.aggregations.seen_routing_keys.buckets);
                 setSeenQueues(result.aggregations.seen_queues.buckets);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

patch

* **What is the current behavior?** (You can also link to an open issue here)

The state filter options are not persistent https://github.com/kodless/leek/issues/9.

* **What is the new behavior (if this is a feature change)?**

Make state filter options persistent event if there are 0 seen events for state options

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

<img width="355" alt="Screen Shot 2021-04-28 at 00 15 36" src="https://user-images.githubusercontent.com/56397909/116328074-b310ab80-a7b7-11eb-868e-722b6f42169d.png">
