### PR TITLE
Ability to retry a task

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ services:
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
         {
-          "default": {
+          "leek-prod": {
             "broker": "amqp://admin:admin@mq//",
             "backend": null,
             "exchange": "celeryev",

--- a/app/leek/api/blueprints.py
+++ b/app/leek/api/blueprints.py
@@ -5,6 +5,7 @@ from leek.api.routes.applications import applications_bp
 from leek.api.routes.events import events_bp
 from leek.api.routes.search import search_bp
 from leek.api.routes.agent import agent_bp
+from leek.api.routes.control import control_bp
 
 
 def register_blueprints(app):
@@ -16,3 +17,4 @@ def register_blueprints(app):
     app.register_blueprint(events_bp)
     app.register_blueprint(search_bp)
     app.register_blueprint(agent_bp)
+    app.register_blueprint(control_bp)

--- a/app/leek/api/channels/slack.py
+++ b/app/leek/api/channels/slack.py
@@ -59,7 +59,7 @@ def send_slack(app_name: str, event: Union[Task, Worker], wh_url: str, extra: di
             {
                 "color": get_color(event.state),
                 "title": f"Task: {event.name}",
-                "title_link": f"{settings.LEEK_WEB_URL}/tasks?app={app_name}&uuid={event.uuid}",
+                "title_link": f"{settings.LEEK_WEB_URL}/task?app={app_name}&uuid={event.uuid}",
                 "fields": fields,
             },
         ],

--- a/app/leek/api/control/task.py
+++ b/app/leek/api/control/task.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def retry_task(app_name, task_doc):
-    # Check
+    # Check if task is routable
     if not task_doc.get("exchange", "tasks") and not task_doc.get("routing_key"):
         return responses.task_not_routable
 

--- a/app/leek/api/control/task.py
+++ b/app/leek/api/control/task.py
@@ -1,0 +1,137 @@
+import ast
+import logging
+import time
+
+from kombu.utils.uuid import uuid
+from kombu import Connection
+from amqp import AccessRefused
+
+from leek.api.conf import settings
+from leek.api.errors import responses
+from leek.api.control.utils import get_subscription
+
+logger = logging.getLogger(__name__)
+
+
+def retry_task(app_name, task_doc):
+    # Check
+    if not task_doc.get("exchange", "tasks") and not task_doc.get("routing_key"):
+        return responses.task_not_routable
+
+    # Check if agent is local
+    if not settings.LEEK_ENABLE_AGENT:
+        return responses.control_operations_not_supported
+
+    # Retrieve subscription
+    subscription = get_subscription(f"{app_name}-{task_doc['app_env']}")
+    if subscription is None:
+        return responses.task_retry_subscription_not_found
+
+    # Prepare connection/producer
+    # noinspection PyBroadException
+    try:
+        connection = Connection(subscription["broker"])
+        connection.ensure_connection(max_retries=2)
+        producer = connection.Producer()
+    except AccessRefused:
+        return responses.wrong_access_refused
+    except Exception:
+        return responses.broker_not_reachable
+
+    # Prepare args
+    argsrepr = task_doc.get("args") or "()"
+    kwargsrepr = task_doc.get("kwargs") or "{}"
+    # noinspection PyBroadException
+    try:
+        args = ast.literal_eval(argsrepr)
+        kwargs = ast.literal_eval(kwargsrepr)
+    except Exception:
+        return responses.malformed_args_or_kwarg_repr
+
+    # Prepare task ids
+    task_id = uuid()
+    if not task_doc.get("root_id"):
+        root_id = task_id
+    else:
+        root_id = None
+
+    headers = {
+        "lang": "py",
+        "task": task_doc["name"],
+        "id": task_id,
+        "shadow": None,
+        "eta": None,
+        "expires": None,
+        "group": None,
+        "group_index": None,
+        "retries": 0,
+        "timelimit": [None, None],
+        "root_id": root_id,
+        "parent_id": task_doc.get("parent_id"),
+        "argsrepr": argsrepr,
+        "kwargsrepr": kwargsrepr,
+        "origin": "leek@control",
+        "ignore_result": True,
+    }
+    properties = {
+        "correlation_id": task_id,
+        "reply_to": '',
+    }
+    body = (
+        args, kwargs, {
+            "callbacks": None,
+            "errbacks": None,
+            "chain": None,
+            "chord": None,
+        },
+    )
+    # Queue actual task
+    producer.publish(
+        body,
+        exchange=task_doc["exchange"],
+        routing_key=task_doc["routing_key"],
+        serializer="json",
+        compression=None,
+        retry=False,
+        delivery_mode=2,  # Persistent
+        headers=headers,
+        **properties
+    )
+    # Send task-sent event
+    sent_event = {
+        "type": "task-sent",
+        "uuid": task_id,
+        "root_id": root_id,
+        "parent_id": task_doc.get("parent_id"),
+        "name": task_doc["name"],
+        "args": argsrepr,
+        "kwargs": kwargsrepr,
+        "retries": 0,
+        "eta": None,
+        "expires": None,
+        # --
+        "queue": task_doc["queue"],
+        "exchange": task_doc["exchange"],
+        "routing_key": task_doc["routing_key"],
+        # --
+        "hostname": "leek@control",
+        "utcoffset": time.timezone // 3600,
+        "pid": 1,
+        "clock": 1,
+        "timestamp": time.time(),
+    }
+    # noinspection PyBroadException
+    try:
+        producer.publish(
+            sent_event,
+            routing_key=subscription["routing_key"],
+            exchange=subscription["exchange"],
+            retry=False,
+            serializer="json",
+            headers={"hostname": "leek@control"},
+            delivery_mode=2,
+        )
+    except Exception as ex:
+        logger.warning(f"Failed to send `task-sent` event for the retried task! with exception: {ex}")
+    connection.release()
+    return {"task_id": task_id}, 200

--- a/app/leek/api/control/utils.py
+++ b/app/leek/api/control/utils.py
@@ -1,0 +1,9 @@
+import json
+
+SUBSCRIPTIONS_FILE = "/opt/app/conf/subscriptions.json"
+
+
+def get_subscription(subscription_name):
+    with open(SUBSCRIPTIONS_FILE) as json_file:
+        subscriptions = json.load(json_file)
+    return subscriptions.get(subscription_name)

--- a/app/leek/api/db/search.py
+++ b/app/leek/api/db/search.py
@@ -16,3 +16,8 @@ def search_index(index_alias, query, params):
         return responses.cache_backend_unavailable
     except es_exceptions.NotFoundError:
         return responses.application_not_found
+
+
+def get_task_by_uuid(index_alias, task_uuid):
+    connection = es.connection
+    return connection.get(index=index_alias, id=task_uuid)

--- a/app/leek/api/errors/responses.py
+++ b/app/leek/api/errors/responses.py
@@ -22,6 +22,14 @@ application_not_found = {
                             }
                         }, 404
 
+task_retry_subscription_not_found = {
+                                        "error": {
+                                            "code": "404002",
+                                            "message": "Task failed to retry",
+                                            "reason": "Subscription not found, subscription names should be in the form of `app_name-env_name`"
+                                        }
+                                    }, 404
+
 wrong_application_app_key = {
                                 "error": {
                                     "code": "401001",
@@ -52,6 +60,31 @@ no_subscriptions_found = {
                                  "reason": "No subscriptions found, agent not started!"
                              }
                          }, 400
+
+malformed_args_or_kwarg_repr = {
+                               "error": {
+                                   "code": "400004",
+                                   "message": "Malformed args or kwargs",
+                                   "reason": "In order for the apply to work, please make sure the args/kwargs "
+                                             "are not truncated by increasing resultrepr_maxsize"
+                               }
+                           }, 400
+
+control_operations_not_supported = {
+                                   "error": {
+                                       "code": "400005",
+                                       "message": "Operation not supported",
+                                       "reason": "Control operations available only if agent is local"
+                                   }
+                               }, 400
+
+task_not_routable = {
+                        "error": {
+                            "code": "400005",
+                            "message": "Task not routable",
+                            "reason": "Task does not have a routing key"
+                        }
+                    }, 400
 
 broker_not_reachable = {
                            "error": {

--- a/app/leek/api/errors/responses.py
+++ b/app/leek/api/errors/responses.py
@@ -80,7 +80,7 @@ control_operations_not_supported = {
 
 task_not_routable = {
                         "error": {
-                            "code": "400005",
+                            "code": "400006",
                             "message": "Task not routable",
                             "reason": "Task does not have a routing key"
                         }

--- a/app/leek/api/routes/control.py
+++ b/app/leek/api/routes/control.py
@@ -1,0 +1,40 @@
+import logging
+
+from flask import Blueprint, request, g
+from flask_restx import Resource
+from elasticsearch import exceptions as es_exceptions
+
+from leek.api.decorators import auth
+from leek.api.db import search
+from leek.api.routes.api_v1 import api_v1
+from leek.api.control import task
+from leek.api.errors import responses
+
+control_bp = Blueprint('control', __name__, url_prefix='/v1/control')
+control_ns = api_v1.namespace('control', 'Celery controlLer')
+
+logger = logging.getLogger(__name__)
+
+
+@control_ns.route('/tasks/<string:task_uuid>/retry')
+class TaskRetry(Resource):
+
+    @auth
+    def post(self, task_uuid):
+        """
+        Retry a celery task
+        """
+        app_name = request.headers["x-leek-app-name"]
+        org_name = g.org_name
+        index_alias = f"{org_name}-{app_name}"
+        try:
+            task_doc = search.get_task_by_uuid(
+                index_alias=index_alias,
+                task_uuid=task_uuid
+            )
+            return task.retry_task(app_name, task_doc["_source"])
+        except es_exceptions.ConnectionError:
+            return responses.cache_backend_unavailable
+        except es_exceptions.NotFoundError:
+            return responses.application_not_found
+

--- a/app/web/src/api/control.tsx
+++ b/app/web/src/api/control.tsx
@@ -1,0 +1,35 @@
+import getFirebase from "../utils/firebase";
+import env from "../utils/vars";
+import {Task, TaskFilters} from "./task";
+
+export interface Control {
+    retryTask(
+        app_name: string,
+        task_uuid: string,
+    ): any;
+}
+
+export class ControlService implements Control {
+    retryTask(
+        app_name: string,
+        task_uuid: string,
+    ) {
+        let fb = getFirebase();
+        if (fb && fb.auth().currentUser) {
+            return fb.auth().currentUser.getIdToken().then(token =>
+                fetch(
+                    `${env.LEEK_API_URL}/v1/control/tasks/${task_uuid}/retry`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Authorization": `Bearer ${token}`,
+                            "Content-Type": "application/json",
+                            "x-leek-app-name": app_name
+                        },
+                        body: JSON.stringify({})
+                    }
+                )
+            );
+        } else return Promise.reject("unauthenticated")
+    }
+}

--- a/app/web/src/containers/tasks/TaskDetailsDrawer.style.tsx
+++ b/app/web/src/containers/tasks/TaskDetailsDrawer.style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 const TaskDetailsDrawer = styled.div`
+  width: 100%;
   .ant-list-item-meta-content {
     width: 100%;
   }

--- a/app/web/src/pages/task.tsx
+++ b/app/web/src/pages/task.tsx
@@ -1,0 +1,77 @@
+import React, {useState, useEffect} from "react";
+import {Helmet} from 'react-helmet'
+import {useQueryParam, StringParam} from "use-query-params";
+import {Row, message} from 'antd'
+
+import TaskDetailsDrawer from '../containers/tasks/TaskDetailsDrawer'
+
+import {useApplication} from "../context/ApplicationProvider"
+import {TaskService} from "../api/task"
+import {handleAPIError, handleAPIResponse} from "../utils/errors"
+
+let timeout;
+
+const TaskPage: React.FC = () => {
+    // STATE
+    const service = new TaskService();
+    const {currentApp} = useApplication();
+    const [qpTaskUUID, setQPTaskUUID] = useQueryParam("uuid", StringParam);
+    const [task, setTask] = useState({});
+
+    // Data
+    const [loading, setLoading] = useState<boolean>(false);
+
+    // API Calls
+    function getTaskByUUID(uuid: string) {
+        if (!currentApp) return;
+        setLoading(true);
+        service.getById(currentApp, uuid)
+            .then(handleAPIResponse)
+            .then((result: any) => {
+                if (result.hits.total == 0) {
+                    message.warning("Task not found, maybe its very old");
+                    return;
+                }
+                setTask(result.hits.hits[0]._source);
+            }, handleAPIError)
+            .catch(handleAPIError)
+            .finally(() => setLoading(false));
+    }
+
+    useEffect(() => {
+        // Stop refreshing metadata
+        if (timeout) clearInterval(timeout);
+        if (qpTaskUUID) {
+            getTaskByUUID(qpTaskUUID)
+        }
+        timeout = setInterval(() => {
+            if (qpTaskUUID) {
+                getTaskByUUID(qpTaskUUID);
+            }
+        }, 5000);
+
+        return () => {
+            clearInterval(timeout);
+        }
+    }, []);
+
+    return (
+        <>
+            <Helmet
+                title="Task detail"
+                meta={[
+                    {name: 'description', content: 'Task details'},
+                    {name: 'keywords', content: 'celery, tasks'},
+                ]}
+            >
+                <html lang="en"/>
+            </Helmet>
+
+            <Row style={{marginTop: "20px", width: "100%"}} gutter={[12, 12]}>
+                <TaskDetailsDrawer task={task} loading={loading}/>
+            </Row>
+        </>
+    )
+};
+
+export default TaskPage

--- a/demo/docker-compose-redis.yml
+++ b/demo/docker-compose-redis.yml
@@ -27,7 +27,7 @@ services:
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
         {
-          "default": {
+          "leek-prod": {
             "broker": "redis://:admin@mq:6379/0",
             "backend": null,
             "exchange": "celeryev",

--- a/demo/docker-compose-rmq.yml
+++ b/demo/docker-compose-rmq.yml
@@ -27,7 +27,7 @@ services:
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
         {
-          "default": {
+          "leek-prod": {
             "broker": "amqp://admin:admin@mq//",
             "backend": null,
             "exchange": "celeryev",

--- a/doc/docs/getting-started/docker.md
+++ b/doc/docs/getting-started/docker.md
@@ -89,7 +89,7 @@ services:
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
         {
-          "default": {
+          "leek-prod": {
             "broker": "amqp://admin:admin@mq//",
             "backend": null,
             "exchange": "celeryev",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
         {
-          "default": {
+          "leek-prod": {
             "broker": "amqp://admin:admin@mq//",
             "backend": null,
             "exchange": "celeryev",


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior?** (You can also link to an open issue here)

Leek does not support control features like retrying tasks and developers have to ssh to a celery application host in order to do that, and that's even harder if a task has args or kwargs.

### What is the new behavior (if this is a feature change)?

As a first initiative to support control features, developers will be able to retry tasks in the state `FAILED` or `CRITICAL` by selecting a task and clicking on `Retry` button.

The retry button will only only be visible for tasks with `FAILED` or `CRITICAL` states.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Now subscription names should be in the form of `app_name-env_name` for example `leek-prod`, this change is now required in order for the API to get broker url from subscription config file using the application name and application env.

This PR will not break the current setup, but developers will not able to retry a task and the API will return 

### Other information:

Some limitations apply:
- Tasks retries will only work with leek applications that have a local agent enabled and subscription name in the form of `app_name-env_name`
- Tasks part of chains, groups or chords will not be retried as part of them.
- Tasks stored without `exchange`, `routing_key` will not be retried and the API will return a warning indicating that the task is not routable, this happens if leek did not receive the related `task-sent` event of the task to be retried because the routing config is only sent by that event.
- Tasks with truncated args/kwargs will not be retried and the API will return a warning indicating that it has detected that the args/kwargs are malformed and celery clients/workers should be configured with a high `resultrepr_maxsize`
- Leek API should be waitlisted by the broker ingress rules
- Subscription username should have permission to publish messages to broker.