### PR TITLE
Concurrency pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ services:
             "routing_key": "#",
             "org_name": "example.com",
             "app_name": "leek",
-            "app_env": "prod"
+            "app_env": "prod",
+            "concurrency_pool_size": 2
           }
         }
       - LEEK_AGENT_API_SECRET=not-secret

--- a/app/leek/agent/logger.py
+++ b/app/leek/agent/logger.py
@@ -1,9 +1,22 @@
 import logging
 import os
 
+import gevent
+
+
+class Adapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        try:
+            greenlet_name = gevent.getcurrent().name
+        except AttributeError:
+            greenlet_name = "main"
+        msg = '(%s) %s' % (greenlet_name, msg)
+        return msg, kwargs
+
+
 logging.basicConfig(level=os.environ.get('LEEK_AGENT_LOG_LEVEL', 'INFO'), format="%(levelname)s:%(name)s:%(message)s")
 
 
 # TODO: Add logs formatter
 def get_logger(name):
-    return logging.getLogger(name)
+    return Adapter(logging.getLogger(name), {})

--- a/app/leek/api/schemas/subscription.py
+++ b/app/leek/api/schemas/subscription.py
@@ -1,4 +1,4 @@
-from schema import Schema, And, Optional
+from schema import Schema, And, Optional, Use
 
 SubscriptionSchema = Schema({
     "name": And(str, len),
@@ -9,4 +9,5 @@ SubscriptionSchema = Schema({
     Optional("exchange", default="celeryev"): And(str, len),
     Optional("queue", default="leek.fanout"): And(str, len),
     Optional("routing_key", default="#"): And(str, len),
+    Optional("concurrency_pool_size", default=1): And(Use(int), lambda n: 1 <= n <= 20),
 })

--- a/app/web/src/containers/agent/AddSubscription.tsx
+++ b/app/web/src/containers/agent/AddSubscription.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Button, Modal, Form, Input, Divider, Space, Select} from 'antd'
+import {Button, Modal, Form, Input, Divider, Space, Select, InputNumber} from 'antd'
 import {DeploymentUnitOutlined, NodeIndexOutlined} from "@ant-design/icons";
 
 
@@ -91,6 +91,16 @@ const AddSubscription = (props) => {
                     rules={[]}
                 >
                     <Input placeholder="Routing Key - default: #"/>
+                </FormItem>
+
+                <FormItem
+                    name="concurrency_pool_size"
+                    rules={[]}
+                >
+                    <InputNumber min={1} max={20} step={1}
+                                 placeholder="Concurrency pool size - default: 1"
+                                 style={{width: "100%"}}
+                    />
                 </FormItem>
             </Form>
         </Modal>

--- a/app/web/src/containers/agent/Subscriptions.tsx
+++ b/app/web/src/containers/agent/Subscriptions.tsx
@@ -129,22 +129,28 @@ const Subscriptions = (props) => {
                        expandable={{
                            expandedRowRender: record => <>
                                <Row justify="space-between" style={{marginBottom: 6}}>
-                                   <Col span={8}>
+                                   <Col span={6}>
                                        <List.Item.Meta
                                            title={"Exchange"}
                                            description={<Tag>{record.exchange}</Tag>}
                                        />
                                    </Col>
-                                   <Col span={8}>
+                                   <Col span={6}>
                                        <List.Item.Meta
                                            title={"Queue"}
                                            description={<Tag>{record.queue}</Tag>}
                                        />
                                    </Col>
-                                   <Col span={8}>
+                                   <Col span={6}>
                                        <List.Item.Meta
                                            title={"Routing key"}
                                            description={<Tag>{record.routing_key}</Tag>}
+                                       />
+                                   </Col>
+                                   <Col span={6}>
+                                       <List.Item.Meta
+                                           title={"Concurrency pool size"}
+                                           description={<Tag>{record.concurrency_pool_size}</Tag>}
                                        />
                                    </Col>
                                </Row>

--- a/demo/docker-compose-redis.yml
+++ b/demo/docker-compose-redis.yml
@@ -35,7 +35,8 @@ services:
             "routing_key": "#",
             "org_name": "obytes.com",
             "app_name": "leek",
-            "app_env": "prod"
+            "app_env": "prod",
+            "concurrency_pool_size": 2
           }
         }
       - LEEK_AGENT_API_SECRET=not-secret

--- a/demo/docker-compose-rmq.yml
+++ b/demo/docker-compose-rmq.yml
@@ -35,7 +35,8 @@ services:
             "routing_key": "#",
             "org_name": "obytes.com",
             "app_name": "leek",
-            "app_env": "prod"
+            "app_env": "prod",
+            "concurrency_pool_size": 2
           }
         }
       - LEEK_AGENT_API_SECRET=not-secret

--- a/doc/docs/getting-started/agent.md
+++ b/doc/docs/getting-started/agent.md
@@ -83,7 +83,8 @@ illustrate how you can subscribe to multiple brokers:
     "app_name": "leek",
     "app_env": "qa",
     "app_key": "not-secret",
-    "api_url": "http://0.0.0.0:5000"
+    "api_url": "http://0.0.0.0:5000",
+    "concurrency_pool_size": 2
   },
  "leek-prod": {
     "broker": "amqp://admin:admin@mq-prod//",
@@ -95,7 +96,8 @@ illustrate how you can subscribe to multiple brokers:
     "app_name": "leek",
     "app_env": "prod",
     "app_key": "not-secret",
-    "api_url": "http://0.0.0.0:5000"
+    "api_url": "http://0.0.0.0:5000",
+    "concurrency_pool_size": 2
   }
 }
 ```

--- a/doc/docs/getting-started/docker.md
+++ b/doc/docs/getting-started/docker.md
@@ -97,7 +97,8 @@ services:
             "routing_key": "#",
             "org_name": "example.com",
             "app_name": "leek",
-            "app_env": "prod"
+            "app_env": "prod",
+            "concurrency_pool_size": 3
           }
         }
       - LEEK_AGENT_API_SECRET=not-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
             "routing_key": "#",
             "org_name": "ramp.com",
             "app_name": "leek",
-            "app_env": "prod"
+            "app_env": "prod",
+            "concurrency_pool_size": 3
           }
         }
       - LEEK_AGENT_API_SECRET=not-secret


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Features

### What is the current behavior? (You can also link to an open issue here)

Leek agent only operates with one consumer on each subscriptions process, in environments where there are huge amount of events, the agent cannot process the events rapidly, the consuming rate drops, the fanout queue get larger and larger and as a result of that you will not be able to see new events as they come late.

### What is the new behavior (if this is a feature change)?

To improve the current behaviour: 

- First, use requests session to enable persistent HTTP connections so we don't have to establish a new connection every time.
- Second, Introduce a gevent concurrency pool to spawn multiple greenlets and each greenlet will have a consumer instance so requests will be sent to the API concurrently. the concurrency pool size is controlled using `concurrency_pool_size` in subscription config environment variable. using too many greenlets may hurt the performance instead of improving it so treat it with caution.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, the `concurrency_pool_size` can be added to subscriptions config but if it does not exist it will fallback to 1.

### Other information:

You will also be able to manage concurrency pool size during runtime using the agent tab in leek ui console.