### PR TITLE
Upsert events concurrently

### DIFF
--- a/app/conf/painless/TaskMerge.groovy
+++ b/app/conf/painless/TaskMerge.groovy
@@ -1,0 +1,140 @@
+String QUEUED = "QUEUED";
+String RECEIVED = "RECEIVED";
+String STARTED = "STARTED";
+String SUCCEEDED = "SUCCEEDED";
+String FAILED = "FAILED";
+String REJECTED = "REJECTED";
+String REVOKED = "REVOKED";
+String RETRY = "RETRY";
+
+// CUSTOM STATES
+String RECOVERED = "RECOVERED"; // Succeeded after many retries
+String CRITICAL = "CRITICAL";  // Failed after max retries
+
+List STATES_TERMINAL = [SUCCEEDED, FAILED, REJECTED, REVOKED, RECOVERED, CRITICAL];
+List STATES_SUCCESS = [SUCCEEDED, RECOVERED];
+List STATES_EXCEPTION = [FAILED, RETRY, REJECTED, REVOKED, CRITICAL];
+List STATES_UNREADY = [QUEUED, RECEIVED, STARTED];
+
+Map TaskStateFields = [
+    // No need to update this fields if coming task is out of order
+    "SHARED": ["_id", "app_env", "kind", "state", "uuid", "clock", "timestamp", "exact_timestamp", "utcoffset", "pid"],
+
+    // Shared between states
+    "QUEUED_RECEIVED": ["name", "args", "kwargs", "root_id", "parent_id", "eta", "expires", "retries"],
+    "FAILED_RETRY": ["exception", "traceback"],
+
+    // Safe
+    "NOT_QUEUED": ["worker"],
+    "QUEUED": ["queued_at", "exchange", "routing_key", "queue", "client"],
+    "RECEIVED": ["received_at"],
+    "STARTED": ["started_at"],
+    "RETRY": ["retried_at"],
+
+    // TERMINAL STATES
+    "SUCCEEDED": ["succeeded_at", "result", "runtime"],
+    "FAILED": ["failed_at"],
+    "REJECTED": ["rejected_at", "requeue"],
+    "REVOKED": ["revoked_at", "terminated", "expired", "signum"]
+];
+
+int events_count = ctx._source.events_count;
+List events = ctx._source.events;
+List attrs_to_upsert = [];
+
+if (ctx._source.uuid == null || STATES_TERMINAL.contains(params.state)) {
+    // First time to index or Coming event in terminal state and safe to merge
+    // No need to compare clocks/timestamps
+    for (def entry : params.entrySet()) {
+        if (entry.getValue() != null) {
+            ctx._source[entry.getKey()] = entry.getValue();
+        }
+    }
+}
+else if (STATES_TERMINAL.contains(ctx._source.state)) {
+    // The task is already in terminal state, Resolve conflict and merge
+    // This can be caused if the timestamp of the new event is inaccurate
+    // Or if the workers/clients are not synchronized
+
+    // Get safe attrs from coming task
+    attrs_to_upsert.addAll(TaskStateFields[params.state]);
+    // States with same attrs
+    if (params.state == RETRY){
+        if (![FAILED, CRITICAL].contains(ctx._source.state)){
+            // Retry event came late => update document with traceback/exception
+            attrs_to_upsert.addAll(TaskStateFields.FAILED_RETRY);
+        }
+    }
+    else if ([QUEUED, RECEIVED].contains(params.state)) {
+        // QUEUED|RECEIVED event came late, update with attrs send only by QUEUED|RECEIVED events
+        attrs_to_upsert.addAll(TaskStateFields.QUEUED_RECEIVED);
+    }
+    // Merge
+    for (def entry : params.entrySet()) {
+        if (entry.getValue() != null && attrs_to_upsert.contains(entry.getKey())) {
+            ctx._source[entry.getKey()] = entry.getValue();
+        }
+    }
+}
+else {
+    // Handle non terminal events (Resolve conflict and merge or Just merge)
+    boolean in_order = ctx._source.exact_timestamp < params.exact_timestamp;
+    if (in_order) {
+        // The two documents are in physical clock order and in state order, Safe to merge
+        for (def entry : params.entrySet()) {
+            if (entry.getValue() != null) {
+                ctx._source[entry.getKey()] = entry.getValue();
+            }
+        }
+    }
+    else if (ctx._source.state == params.state) {
+        // The two documents are out of order and has the same state => Skip
+        ctx.op = 'none';
+    }
+    else {
+        // The two documents are out of order and has different states => Resolve conflict and merge
+
+        // Get safe attrs from coming task
+        attrs_to_upsert.addAll(TaskStateFields[params.state]);
+        // States with same attrs
+        if (params.state == RETRY) {
+            if (ctx._source.state != RETRY) {
+                attrs_to_upsert.addAll(TaskStateFields.FAILED_RETRY);
+            }
+        }
+        else if ([QUEUED, RECEIVED].contains(params.state)) {
+            if (![QUEUED, RECEIVED].contains(ctx._source.state)) {
+                attrs_to_upsert.addAll(TaskStateFields.QUEUED_RECEIVED);
+            }
+        }
+        // Merge
+        for (def entry : params.entrySet()) {
+            if (entry.getValue() != null && attrs_to_upsert.contains(entry.getKey())) {
+                ctx._source[entry.getKey()] = entry.getValue();
+            }
+        }
+    }
+}
+
+// Introduce custom states
+if (ctx._source.retries != null && ctx._source.retries > 0) {
+    if (ctx._source.state == FAILED) {
+        ctx._source.state = CRITICAL;
+    }
+    else if (ctx._source.state == SUCCEEDED) {
+        ctx._source.state = RECOVERED;
+    }
+}
+
+// If parent/root is self fix
+if (ctx._source.root_id != null && ctx._source.root_id.equals(ctx._source.id) ) {
+    ctx._source.root_id = null;
+}
+if (ctx._source.parent_id != null && ctx._source.parent_id.equals(ctx._source.id) ) {
+    ctx._source.parent_id = null;
+}
+
+// Increment events count
+ctx._source.events_count = events_count + 1;
+events.add(params.state);
+ctx._source.events = events;

--- a/app/conf/painless/WorkerMerge.groovy
+++ b/app/conf/painless/WorkerMerge.groovy
@@ -1,0 +1,40 @@
+Map WorkerStateFields = [
+        // No need to update this fields if coming task is out of order
+        "SHARED"   : [
+                "_id", "app_env", "kind", "state", "hostname", "clock", "timestamp", "exact_timestamp", "utcoffset", "pid",
+                "sw_ident", "sw_ver", "sw_sys"
+        ],
+        // Safe
+        "ONLINE"   : ["online_at"],
+        "HEARTBEAT": ["last_heartbeat_at", "processed", "active", "freq", "loadavg"],
+        "OFFLINE"  : ["offline_at"]
+];
+
+int events_count = ctx._source.events_count;
+boolean in_order = ctx._source.exact_timestamp < params.exact_timestamp;
+List attrs_to_upsert = [];
+
+if (in_order) {
+    // The two documents are in order, Safe to merge
+    for (def entry : params.entrySet()) {
+        if (entry.getValue() != null) {
+            ctx._source[entry.getKey()] = entry.getValue();
+        }
+    }
+} else if (!in_order && ctx._source.state == params.state) {
+    // The two documents are out of order and has the same state => Skip
+    ctx.op = 'none';
+} else {
+    // The two documents are out of order and has different states => Resolve conflict and merge
+
+    // Get safe attrs from coming worker event
+    attrs_to_upsert.addAll(WorkerStateFields[params.state]);
+    // Merge
+    for (def entry : params.entrySet()) {
+        if (entry.getValue() != null && attrs_to_upsert.contains(entry.getKey())) {
+            ctx._source[entry.getKey()] = entry.getValue();
+        }
+    }
+}
+
+ctx._source.events_count = events_count + 1;

--- a/app/leek/agent/agent.py
+++ b/app/leek/agent/agent.py
@@ -1,10 +1,8 @@
-import json
-
 import gevent
 from gevent import monkey
-
 monkey.patch_all()
 
+import json
 from signal import signal, SIGTERM
 from multiprocessing import Process
 
@@ -57,7 +55,7 @@ class LeekAgent:
 
         signal(SIGTERM, self.stop)
         for consumer in self.consumers:
-            p = Process(target=self.start_pool, args=(consumer,))
+            p = Process(target=consumer.run)
             p.start()
             self.proc.append(p)
 
@@ -71,15 +69,6 @@ class LeekAgent:
         print("SIGTERM detected. Exiting gracefully")
         for p in self.proc:
             p.kill()
-
-    @staticmethod
-    def start_pool(consumer: LeekConsumer):
-        greenlets = []
-        for C in range(0, consumer.concurrency_pool_size):
-            greenlet = gevent.spawn(consumer.run, )
-            greenlet.name = f"consumer.{consumer.subscription_name}.{C}"
-            greenlets.append(greenlet)
-        gevent.joinall(greenlets, raise_error=True)
 
 
 if __name__ == '__main__':

--- a/app/leek/api/db/events.py
+++ b/app/leek/api/db/events.py
@@ -9,76 +9,39 @@ from leek.api.errors import responses
 from leek.api.ext import es
 
 
-class RetrieveIndexedError(Exception):
-    pass
-
-
-def retrieve_indexed(index_alias, new_events: Dict[str, Union[Task, Worker]]):
-    connection = es.connection
-    # Retrieving existing events
-    ids = []
-    for _id in new_events.keys():
-        ids.append(_id)
-    # Impossible
-    if len(ids) != len(set(ids)):
-        raise RetrieveIndexedError("Found events with the same id in the payload")
-    return connection.mget(
-        body={'ids': ids},
-        index=index_alias
-    )["docs"]
-
-
-def upsert_concurrently(index_alias, new_events: Dict[str, Union[Task, Worker]]):
-    indexed_events = retrieve_indexed(index_alias, new_events)
-    # Precedence check
-    updated = {}
-    for event in indexed_events:
-        # If the task is already indexed, update it
-        _id = event["_id"]
-        new_doc = new_events[_id]
-        try:
-            found = event["found"]
-        except KeyError:
-            raise RetrieveIndexedError("Index not found")
-        if found:
-            source = event["_source"]
-            if source["kind"] == "task":
-                task = Task(id=_id, **source, )
-                task.merge(new_doc)
-                updated[_id] = task
-            elif source["kind"] == "worker":
-                worker = Worker(id=_id, **source, )
-                worker.merge(new_doc)
-                updated[_id] = worker
-        else:
-            updated[_id] = new_doc
-    return updated
-
-
 def build_actions(index_alias: str, events: Dict[str, Union[Task, Worker]]):
     actions = []
     for _, event in events.items():
         _id, doc = event.to_doc()
-        actions.append({
+        action = {
             "_id": _id,
-            "_op_type": "index",
+            "_op_type": "update",
             "_index": index_alias,
-            "_source": doc,
-        })
+            "retry_on_conflict": 10,
+            "script": {
+                "id": "task-merge" if event.kind == "task" else "worker-merge",
+                "params": doc
+            },
+            "upsert": doc
+        }
+        actions.append(action)
     return actions
 
 
 def merge_events(index_alias, events: Dict[str, Union[Task, Worker]]):
     connection = es.connection
     try:
-        safe_events = upsert_concurrently(index_alias, events)
-        actions = build_actions(index_alias, safe_events)
+        actions = build_actions(index_alias, events)
         if len(actions):
             updated = []
-            for ok, item in streaming_bulk(connection, actions, index=index_alias, _source=True):
+            for ok, item in streaming_bulk(
+                    connection, actions,
+                    index=index_alias,
+                    _source=True
+            ):
                 if ok:
-                    _id = item["index"]["_id"]
-                    updated.append(safe_events[_id])
+                    _id = item["update"]["_id"]
+                    updated.append(events[_id])
             return updated, 201
         else:
             return [], 201
@@ -90,5 +53,3 @@ def merge_events(index_alias, events: Dict[str, Union[Task, Worker]]):
     except bulk_errors.BulkIndexError as e:
         print(json.dumps(e.errors, indent=4))
         return f"Update error", 409
-    except RetrieveIndexedError as e:
-        return responses.application_not_found

--- a/app/leek/requirements.txt
+++ b/app/leek/requirements.txt
@@ -14,5 +14,5 @@ printy==2.1.1
 supervisor==4.2.1
 
 # Additional for agent
-kombu==5.0.2
+kombu==5.1.0
 redis==3.5.3

--- a/app/web/src/containers/tasks/TaskDetails.style.tsx
+++ b/app/web/src/containers/tasks/TaskDetails.style.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
-const TaskDetailsDrawer = styled.div`
+const TaskDetails = styled.div`
   width: 100%;
   .ant-list-item-meta-content {
     width: 100%;
   }
 `;
 
-export default TaskDetailsDrawer;
+export default TaskDetails;

--- a/app/web/src/containers/tasks/TaskDetails.tsx
+++ b/app/web/src/containers/tasks/TaskDetails.tsx
@@ -4,12 +4,12 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import {atelierCaveDark} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 import {adaptTime} from '../../utils/date'
-import TaskDetailsDrawer from './TaskDetailsDrawer.style'
+import TaskDetails from './TaskDetails.style'
 import {buildTag} from "../../components/data/TaskData";
 import {ControlService} from "../../api/control";
 import {handleAPIError, handleAPIResponse} from "../../utils/errors";
 import {useApplication} from "../../context/ApplicationProvider";
-import {ExclamationCircleOutlined, LoadingOutlined, SyncOutlined} from "@ant-design/icons";
+import {CheckCircleOutlined, ExclamationCircleOutlined, LoadingOutlined, SyncOutlined} from "@ant-design/icons";
 
 const Text = Typography.Text;
 const {TabPane} = Tabs;
@@ -54,7 +54,7 @@ export default props => {
     function retriedSuccessfully(task_id) {
         confirm({
             title: "Task retried!",
-            icon: <ExclamationCircleOutlined/>,
+            icon: <CheckCircleOutlined style={{color: "#00BFA6"}}/>,
             content: <>
                 <Typography.Paragraph>Task retried successfully with uuid <Typography.Text code>{task_id}</Typography.Text></Typography.Paragraph>
             </>,
@@ -70,7 +70,7 @@ export default props => {
     }
 
     return (
-        <TaskDetailsDrawer>
+        <TaskDetails>
             {/* Header */}
 
             <Row justify="space-between">
@@ -353,6 +353,6 @@ export default props => {
                     </List>
                 </TabPane>
             </Tabs>
-        </TaskDetailsDrawer>
+        </TaskDetails>
     );
 };

--- a/app/web/src/pages/task.tsx
+++ b/app/web/src/pages/task.tsx
@@ -3,7 +3,7 @@ import {Helmet} from 'react-helmet'
 import {useQueryParam, StringParam} from "use-query-params";
 import {Row, message} from 'antd'
 
-import TaskDetailsDrawer from '../containers/tasks/TaskDetailsDrawer'
+import TaskDetails from '../containers/tasks/TaskDetails'
 
 import {useApplication} from "../context/ApplicationProvider"
 import {TaskService} from "../api/task"
@@ -68,7 +68,7 @@ const TaskPage: React.FC = () => {
             </Helmet>
 
             <Row style={{marginTop: "20px", width: "100%"}} gutter={[12, 12]}>
-                <TaskDetailsDrawer task={task} loading={loading}/>
+                <TaskDetails task={task} loading={loading}/>
             </Row>
         </>
     )

--- a/app/web/src/pages/tasks.tsx
+++ b/app/web/src/pages/tasks.tsx
@@ -1,13 +1,11 @@
 import React, {useState, useEffect} from "react";
 import {Helmet} from 'react-helmet'
-import {useQueryParam, StringParam} from "use-query-params";
-import {Row, Drawer, message, Col, Table, Button, Switch, Card, Empty} from 'antd'
+import {Row, message, Col, Table, Button, Switch, Card, Empty} from 'antd'
 import {SyncOutlined, CaretUpOutlined, CaretDownOutlined} from '@ant-design/icons'
 
 import TaskDataColumns from "../components/data/TaskData"
 import AttributesFilter from '../components/filters/TaskAttributesFilter'
 import TimeFilter from '../components/filters/TaskTimeFilter'
-import TaskDetailsDrawer from '../containers/tasks/TaskDetailsDrawer'
 
 import {useApplication} from "../context/ApplicationProvider"
 import {TaskService} from "../api/task"
@@ -19,7 +17,6 @@ const TasksPage: React.FC = () => {
     // STATE
     const service = new TaskService();
     const {currentApp, currentEnv} = useApplication();
-    const [qpTaskUUID, setQPTaskUUID] = useQueryParam("uuid", StringParam);
 
     // Filters
     const [filters, setFilters] = useState<any>();
@@ -35,10 +32,6 @@ const TasksPage: React.FC = () => {
     const [pagination, setPagination] = useState<any>({pageSize: 20, current: 1});
     const [loading, setLoading] = useState<boolean>();
     const [tasks, setTasks] = useState<any[]>([]);
-    const [currentTask, setCurrentTask] = useState({});
-
-    // UI
-    const [taskDetailsVisible, setDetailsVisible] = useState(false);
 
     // API Calls
     function filterTasks(pager = {current: 1, pageSize: 20}) {
@@ -86,12 +79,6 @@ const TasksPage: React.FC = () => {
         refresh(pagination)
     }, [currentApp, currentEnv, filters, timeFilters, order]);
 
-    useEffect(() => {
-        if (qpTaskUUID) {
-            getTaskByUUID(qpTaskUUID)
-        }
-    }, []);
-
 
     useEffect(() => {
         //console.log(tasks)
@@ -102,16 +89,8 @@ const TasksPage: React.FC = () => {
         filterTasks(pager)
     }
 
-    function handleHideTaskDetails() {
-        setDetailsVisible(false);
-        setQPTaskUUID(undefined)
-    }
-
     function handleShowTaskDetails(record) {
-        console.log(record);
-        setCurrentTask(record);
-        setQPTaskUUID(record.uuid);
-        setDetailsVisible(true)
+        window.open(`/task?app=${currentApp}&uuid=${record.uuid}`, "_blank")
     }
 
     function handleRefresh() {
@@ -208,16 +187,6 @@ const TasksPage: React.FC = () => {
                     </Row>
                 </Col>
             </Row>
-
-            <Drawer
-                width="50vw"
-                placement="right"
-                closable={false}
-                onClose={handleHideTaskDetails}
-                visible={taskDetailsVisible}
-            >
-                <TaskDetailsDrawer task={currentTask}/>
-            </Drawer>
         </>
     )
 };


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Patch

### What is the current behavior? (You can also link to an open issue here)

After adding gevent concurrency pool to send events concurrently to Leek API. we started noticing inconsistent tasks states due to fast concurrent calls to update the same task with different events. and that's because leek API get the document from the index, updates it with new event and reindex it. 

For example if the document state is changed between the GET and INDEX operations by another concurrent call, the last update wins and the document will be in inconsistent state because the update from the other concurrent event processor is overwritten by the second event processor.

A candidate fix to this was to use elasticsearch UPSERT operation because it detects conflicts by using Elasticsearch versioning system and since we have to:

- Get the task document from elasticsearch
- Compare the existing document with the new one, resolve conflicts and merge the two documents.
- Send UPSERT operation to Elasticsearch with the merged document and Elastricsearch internally will get the existent document update it with the merged document from Leek and commit it and:
  - If the document version is changed between the update and the commit by another concurrent call, Elasticsearch will raise a conflict exception, and the API will have to repeat the process again with the new document (GET, resolve conflict, merge and send UPSERT operation to Elasticsearch).
  - If the document version is not change the upsert will succeed.
  
This approach is very messy in two many angles:
  - There will be a lot of network roundtrips between leek API and Elasticsearch due to conflicts from concurrent calls.
  - The processing rate will extremely drop. and that will invalidate the advantages of concurrency since concurrent calls will not become concurrent anymore.
  -  Leek API Resources usage will increase due to repeated merge logic everytime the conflicts is detected.

### What is the new behavior (if this is a feature change)?

The best approach in my opinion was to use the delegated scripted upserts using Elasticsearch painless scripts.

The logic in Leek API that resolve conflicts is translated to painless scripts one for workers events called `worker-merge` and another for tasks called `tasks-merge`. the scripts are stored during Leek bootstrap in elasticsearch. 

I opted for stored scripts instead of requests inline script to decrease request size and we will not have to send the script body on each upsert request to elasticsearch and the later will have to compile the script on each requests, so the benefits of stored scripts are:

- Compiled only once
- We only have to specify script Id, so the request size will be significantly low.

So how the scripts are used and what are the advantages over the other approach?

On each new event, Leek API will send a scripted upsert request to Elasticsearch with:
- The event document (task or worker)
- The script id
- The max retry on conflict.

Elasticsearch will:
- check if document exist.
- If not, the document will just be inserted.
- If yes, the script will be called.
- The script will compare the new document in `params` object with the existing document in `ctx._source` object.
- The script will do it's magic and merge the two documents and resolve conflicts if there are any.
- Elasticsearch will update the document. if the document is changed by another concurrent user and if a conflict is detected the script will be retried again with new document until reaching the max retry on conflicts

The advantages of this approach are:

- Delegate conflicts resolution to the upstream.
- Eliminates network roundtrips between Leek API and Elasticsearch due to conflicts and as a result of that there will be much fewer conflicts.
- Maintain a higher concurrency rate.
- Alleviate some of the pressure from API that was due to computations used to detect conflicts.

So everyone will be happy:
- The broker will have a smaller fanout queue and decreased memory usage.
- Leek agent will have a lower acknowledgment rate.
- Leek API will have a much lower CPU utilization.
- Elasticsearch will have much lower indexing requests since it can deal with conflicts and will not request the API many time to resolve the conflicts and Get back to it with the new document.

The final result will be faster Leek with consistent messages.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, as soon as you restart Leek, it will start using the new logic

### Other information

💃 