### PR TITLE
Move prefetch count setting to subscription config

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ services:
             "org_name": "example.com",
             "app_name": "leek",
             "app_env": "prod",
+            "prefetch_count": 1000,
             "concurrency_pool_size": 2
           }
         }

--- a/app/bin/bootstrap.py
+++ b/app/bin/bootstrap.py
@@ -151,6 +151,9 @@ def validate_subscriptions(subs):
 
             if not subscription.get("concurrency_pool_size"):
                 subscription["concurrency_pool_size"] = 1
+
+            if not subscription.get("prefetch_count"):
+                subscription["prefetch_count"] = 1000
     return subs
 
 

--- a/app/leek/api/schemas/subscription.py
+++ b/app/leek/api/schemas/subscription.py
@@ -9,5 +9,6 @@ SubscriptionSchema = Schema({
     Optional("exchange", default="celeryev"): And(str, len),
     Optional("queue", default="leek.fanout"): And(str, len),
     Optional("routing_key", default="#"): And(str, len),
+    Optional("prefetch_count", default=1000): And(Use(int), lambda n: 1000 <= n <= 10000),
     Optional("concurrency_pool_size", default=1): And(Use(int), lambda n: 1 <= n <= 20),
 })

--- a/app/web/src/containers/agent/AddSubscription.tsx
+++ b/app/web/src/containers/agent/AddSubscription.tsx
@@ -94,6 +94,16 @@ const AddSubscription = (props) => {
                 </FormItem>
 
                 <FormItem
+                    name="prefetch_count"
+                    rules={[]}
+                >
+                    <InputNumber min={1000} max={10000} step={1}
+                                 placeholder="Prefetch count - default: 1000"
+                                 style={{width: "100%"}}
+                    />
+                </FormItem>
+
+                <FormItem
                     name="concurrency_pool_size"
                     rules={[]}
                 >

--- a/app/web/src/containers/agent/Subscriptions.tsx
+++ b/app/web/src/containers/agent/Subscriptions.tsx
@@ -149,8 +149,8 @@ const Subscriptions = (props) => {
                                    </Col>
                                    <Col span={6}>
                                        <List.Item.Meta
-                                           title={"Concurrency pool size"}
-                                           description={<Tag>{record.concurrency_pool_size}</Tag>}
+                                           title={"Prefetch count/Pool size"}
+                                           description={<Tag>{record.prefetch_count}/{record.concurrency_pool_size}</Tag>}
                                        />
                                    </Col>
                                </Row>

--- a/demo/docker-compose-redis.yml
+++ b/demo/docker-compose-redis.yml
@@ -35,6 +35,7 @@ services:
             "org_name": "obytes.com",
             "app_name": "leek",
             "app_env": "prod",
+            "prefetch_count": 1000,
             "concurrency_pool_size": 2
           }
         }

--- a/demo/docker-compose-rmq.yml
+++ b/demo/docker-compose-rmq.yml
@@ -35,6 +35,7 @@ services:
             "org_name": "obytes.com",
             "app_name": "leek",
             "app_env": "prod",
+            "prefetch_count": 1000,
             "concurrency_pool_size": 2
           }
         }

--- a/doc/docs/getting-started/agent.md
+++ b/doc/docs/getting-started/agent.md
@@ -62,6 +62,11 @@ parameters to connect to the brokers and APIs.
     - **org_name** - leek organisation name (GSuite domain for organizations and GMail user id for individual users)
     - **app_name** - leek application name chosen when creating the application the first time
 
+- Optional parameters - will fallback to defaults if not set:
+  - **prefetch_count** - used to specify how many messages are being sent at the same time from the broker to agent.
+  - **concurrency_pool_size** - The gevent pool size, or the number green threads that the agent can spawn for the 
+    current subscription to send events concurrently to Leek API.
+
 - Optional parameters - only required for standalone agents:
     - **app_key** - the app key generated when creating the application
     - **api_url** - Leek api url
@@ -84,6 +89,7 @@ illustrate how you can subscribe to multiple brokers:
     "app_env": "qa",
     "app_key": "not-secret",
     "api_url": "http://0.0.0.0:5000",
+    "prefetch_count": 1000,
     "concurrency_pool_size": 2
   },
  "leek-prod": {
@@ -97,6 +103,7 @@ illustrate how you can subscribe to multiple brokers:
     "app_env": "prod",
     "app_key": "not-secret",
     "api_url": "http://0.0.0.0:5000",
+    "prefetch_count": 1000,
     "concurrency_pool_size": 2
   }
 }

--- a/doc/docs/getting-started/docker.md
+++ b/doc/docs/getting-started/docker.md
@@ -97,6 +97,7 @@ services:
             "org_name": "example.com",
             "app_name": "leek",
             "app_env": "prod",
+            "prefetch_count": 1000,
             "concurrency_pool_size": 3
           }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
             "org_name": "ramp.com",
             "app_name": "leek",
             "app_env": "prod",
+            "prefetch_count": 1000,
             "concurrency_pool_size": 3
           }
         }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

patch

* **What is the current behavior?** (You can also link to an open issue here)

The prefetch count is set using environment variable

* **What is the new behavior (if this is a feature change)?**

For setting the prefetch count dynamically during runtime the prefetch count can be set using subscription config

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, Leek will no more take `LEEK_AGENT_PREFETCH_COUNT` into consideration so you can start using the new subscription config setting. 
