### PR TITLE
NO-AUTH support

### DIFF
--- a/app/leek/api/conf/settings.py
+++ b/app/leek/api/conf/settings.py
@@ -6,17 +6,18 @@ def get_list(env_name):
     return [x for x in os.environ.get(env_name, "").split(",") if x]
 
 
-def get_bool(env_name):
-    return os.environ.get(env_name) == "true"
+def get_bool(env_name, default="false"):
+    return os.environ.get(env_name, default).lower() == "true"
 
 
 # ES
 LEEK_ES_URL = os.environ.get("LEEK_ES_URL")
 
 # Authentication/Authorization
-LEEK_API_OWNER_ORG = os.environ["LEEK_API_OWNER_ORG"]
+LEEK_API_ENABLE_AUTH = get_bool("LEEK_API_ENABLE_AUTH", "true")
+LEEK_API_OWNER_ORG = os.environ.get("LEEK_API_OWNER_ORG")
 LEEK_API_WHITELISTED_ORGS = get_list("LEEK_API_WHITELISTED_ORGS")
-LEEK_FIREBASE_PROJECT_ID = os.environ["LEEK_FIREBASE_PROJECT_ID"]
+LEEK_FIREBASE_PROJECT_ID = os.environ.get("LEEK_FIREBASE_PROJECT_ID")
 LEEK_API_AUTHORIZED_AUDIENCES = [LEEK_FIREBASE_PROJECT_ID, ]
 
 # Web

--- a/app/leek/api/routes/agent.py
+++ b/app/leek/api/routes/agent.py
@@ -77,7 +77,6 @@ class AgentSubscriptionsList(Resource):
         """
         Get subscriptions
         """
-        app_name = request.headers["x-leek-app-name"]
         with open(SUBSCRIPTIONS_FILE) as s:
             subscriptions = json.load(s)
         app_subscriptions = [
@@ -87,7 +86,7 @@ class AgentSubscriptionsList(Resource):
                 "backend": Connection(subscription.get("backend")).as_uri() if subscription.get("backend") else None
             } for subscription_name, subscription in
             subscriptions.items() if
-            subscription.get("app_name") == app_name and subscription.get("org_name") == g.org_name]
+            subscription.get("app_name") == g.app_name and subscription.get("org_name") == g.org_name]
         return app_subscriptions, 200
 
     # noinspection PyBroadException
@@ -97,11 +96,10 @@ class AgentSubscriptionsList(Resource):
         Add subscription
         """
         data = request.get_json()
-        app_name = request.headers["x-leek-app-name"]
         subscription = SubscriptionSchema.validate(data)
         subscription.update({
             "org_name": g.org_name,
-            "app_name": app_name,
+            "app_name": g.app_name,
             "app_key": settings.LEEK_AGENT_API_SECRET,
             "api_url": settings.LEEK_API_URL
         })

--- a/app/leek/api/routes/applications.py
+++ b/app/leek/api/routes/applications.py
@@ -29,12 +29,15 @@ class Applications(Resource):
         """
         data = request.get_json()
         app = ApplicationSchema.validate(data)
-        org_name = g.org_name
-        template_name = f"{org_name}-{app['app_name']}"
 
+        if hasattr(g, "email"):
+            app["owner"] = g.email
+        else:
+            app["owner"] = "public"
+
+        template_name = f"{g.org_name}-{app['app_name']}"
         app["app_key"] = generate_app_key()
         app["created_at"] = int(round(time.time() * 1000))
-        app["owner"] = g.email
 
         return apps.create_index_template(
             index_alias=template_name,
@@ -47,15 +50,62 @@ class Applications(Resource):
         """
         Retrieve organization applications
         """
-        org_name = g.org_name
-        return apps.get_index_templates(org_name)
+        return apps.get_index_templates(g.org_name)
+
+    @auth(only_app_owner=True)
+    def delete(self):
+        """
+        Delete application
+        """
+        return apps.delete_application(g.index_alias)
 
 
-@applications_ns.route('/<string:app_name>/fo-triggers')
+@applications_ns.route('/purge')
+class PurgeApplication(Resource):
+
+    @auth(only_app_owner=True)
+    def delete(self):
+        """
+        Purge application
+        """
+
+        return apps.purge_application(g.index_alias)
+
+
+@applications_ns.route('/clean')
+class CleanApplication(Resource):
+
+    @auth(only_app_owner=True)
+    def delete(self):
+        """
+        Clean application
+        """
+        data = request.args.to_dict()
+        return apps.clean_documents_older_than(
+            g.index_alias,
+            kind=data["kind"],
+            count=data["count"],
+            unit=data["unit"]
+        )
+
+
+@applications_ns.route('/indices')
+class ApplicationIndices(Resource):
+
+    @auth
+    def get(self):
+        """
+        List application indices
+        """
+
+        return apps.get_application_indices(g.index_alias)
+
+
+@applications_ns.route('/fo-triggers')
 class AddFanoutTriggers(Resource):
 
     @auth(only_app_owner=True)
-    def post(self, app_name):
+    def post(self):
         """
         Create fanout trigger
         """
@@ -63,74 +113,20 @@ class AddFanoutTriggers(Resource):
         trigger = TriggerSchema.validate(data)
         trigger["id"] = ''.join(choice(ascii_uppercase) for i in range(10))
 
-        if not init_trigger(trigger, app_name):
+        if not init_trigger(trigger, g.app_name):
             raise SchemaError(f"Invalid webhook URL")
 
-        org_name = g.org_name
-
         return apps.add_or_update_app_fo_trigger(
-            index_alias=f"{org_name}-{app_name}",
+            index_alias=g.index_alias,
             trigger=trigger
         )
 
 
-@applications_ns.route('/<string:app_name>')
-class DeleteApplication(Resource):
-
-    @auth(only_app_owner=True)
-    def delete(self, app_name):
-        """
-        Delete application
-        """
-        return apps.delete_application(f"{g.org_name}-{app_name}")
-
-
-@applications_ns.route('/<string:app_name>/purge')
-class PurgeApplication(Resource):
-
-    @auth(only_app_owner=True)
-    def delete(self, app_name):
-        """
-        Purge application
-        """
-
-        return apps.purge_application(f"{g.org_name}-{app_name}")
-
-
-@applications_ns.route('/<string:app_name>/clean')
-class CleanApplication(Resource):
-
-    @auth(only_app_owner=True)
-    def delete(self, app_name):
-        """
-        Clean application
-        """
-        data = request.args.to_dict()
-        return apps.clean_documents_older_than(
-            f"{g.org_name}-{app_name}",
-            kind=data["kind"],
-            count=data["count"],
-            unit=data["unit"]
-        )
-
-
-@applications_ns.route('/<string:app_name>/indices')
-class ApplicationIndices(Resource):
-
-    @auth
-    def get(self, app_name):
-        """
-        List application indices
-        """
-
-        return apps.get_application_indices(f"{g.org_name}-{app_name}")
-
-
-@applications_ns.route('/<string:app_name>/fo-triggers/<string:trigger_id>')
+@applications_ns.route('/fo-triggers/<string:trigger_id>')
 class UpdateFanoutTriggers(Resource):
 
     @auth(only_app_owner=True)
-    def put(self, app_name, trigger_id):
+    def put(self, trigger_id):
         """
         Edit fanout trigger
         """
@@ -138,21 +134,17 @@ class UpdateFanoutTriggers(Resource):
         trigger = TriggerSchema.validate(data)
         trigger["id"] = trigger_id
 
-        if not init_trigger(trigger, app_name):
+        if not init_trigger(trigger, g.app_name):
             raise SchemaError(f"Invalid webhook URL")
 
-        org_name = g.org_name
-
         return apps.add_or_update_app_fo_trigger(
-            index_alias=f"{org_name}-{app_name}",
+            index_alias=g.index_alias,
             trigger=trigger
         )
 
     @auth(only_app_owner=True)
-    def delete(self, app_name, trigger_id):
-        org_name = g.org_name
-
+    def delete(self, trigger_id):
         return apps.delete_app_fo_trigger(
-            index_alias=f"{org_name}-{app_name}",
+            index_alias=g.index_alias,
             trigger_id=trigger_id
         )

--- a/app/leek/api/routes/control.py
+++ b/app/leek/api/routes/control.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import Blueprint, request, g
+from flask import Blueprint, g
 from flask_restx import Resource
 from elasticsearch import exceptions as es_exceptions
 
@@ -24,15 +24,12 @@ class TaskRetry(Resource):
         """
         Retry a celery task
         """
-        app_name = request.headers["x-leek-app-name"]
-        org_name = g.org_name
-        index_alias = f"{org_name}-{app_name}"
         try:
             task_doc = search.get_task_by_uuid(
-                index_alias=index_alias,
+                index_alias=g.index_alias,
                 task_uuid=task_uuid
             )
-            return task.retry_task(app_name, task_doc["_source"])
+            return task.retry_task(g.app_name, task_doc["_source"])
         except es_exceptions.ConnectionError:
             return responses.cache_backend_unavailable
         except es_exceptions.NotFoundError:

--- a/app/leek/api/routes/search.py
+++ b/app/leek/api/routes/search.py
@@ -22,9 +22,6 @@ class Search(Resource):
         """
         Search index
         """
-        org_name = g.org_name
-        app_name = request.headers["x-leek-app-name"]
-        index_alias = f"{org_name}-{app_name}"
         query = request.get_json()
         params = SearchParamsSchema.validate(request.args.to_dict())
-        return search_index(index_alias, query, params)
+        return search_index(g.index_alias, query, params)

--- a/app/web/src/api/agent.tsx
+++ b/app/web/src/api/agent.tsx
@@ -1,12 +1,10 @@
-import getFirebase from "../utils/firebase";
-import env from "../utils/vars";
+import {request} from "./request";
+
 
 export interface Agent {
     retrieveAgent(): any;
 
     startOrRestartAgent(): any;
-
-    stopAgent(): any;
 
     stopAgent(): any;
 
@@ -19,99 +17,66 @@ export interface Agent {
 
 export class AgentService implements Agent {
     retrieveAgent() {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/control`, {
-                    method: "GET",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json"
-                    },
-                })
-            );
-        }
+        return request(
+            {
+                method: "GET",
+                path: "/v1/agent/control",
+            }
+        )
     }
 
     startOrRestartAgent() {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/control`, {
-                    method: "POST",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify({})
-                })
-            );
-        }
+        return request(
+            {
+                method: "POST",
+                path: "/v1/agent/control",
+            }
+        )
     }
 
     stopAgent() {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/control`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: "/v1/agent/control",
+            }
+        )
     }
 
     getSubscriptions(app_name) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/subscriptions`, {
-                    method: "GET",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                        "x-leek-app-name": app_name
-                    },
-                })
-            );
-        }
+        return request(
+            {
+                method: "GET",
+                path: "/v1/agent/subscriptions",
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     addSubscription(app_name, subscription) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/subscriptions`, {
-                    method: "POST",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                        "x-leek-app-name": app_name
-                    },
-                    body: JSON.stringify(subscription)
-                })
-            );
-        }
+        return request(
+            {
+                method: "POST",
+                path: "/v1/agent/subscriptions",
+                body: subscription,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     deleteSubscription(app_name, subscription_name) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/agent/subscriptions/${subscription_name}`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: `/v1/agent/subscriptions/${subscription_name}`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 }

--- a/app/web/src/api/application.tsx
+++ b/app/web/src/api/application.tsx
@@ -1,6 +1,5 @@
-import getFirebase from "../utils/firebase";
-import env from "../utils/vars";
 import {buildQueryString} from "./search";
+import {request} from "./request";
 
 export interface Application {
     listApplications(): any;
@@ -24,158 +23,112 @@ export interface Application {
 
 export class ApplicationService implements Application {
     listApplications() {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications`, {
-                    method: "GET",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json"
-                    },
-                })
-            );
-        }
+        return request(
+            {
+                method: "GET",
+                path: "/v1/applications",
+            }
+        )
     }
 
     createApplication(application) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications`, {
-                    method: "POST",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json"
-                    },
-                    body: JSON.stringify(application)
-                })
-            );
-        }
+        return request(
+            {
+                method: "POST",
+                path: "/v1/applications",
+                body: application,
+            }
+        )
     }
 
     purgeApplication(app_name) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/purge`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: `/v1/applications/purge`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     cleanApplication(app_name, kind, count, unit="minutes") {
-        let fb = getFirebase();
         let params = {
             kind: kind,
             count: count,
             unit: unit
         };
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/clean${buildQueryString(params)}`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: `/v1/applications/clean${buildQueryString(params)}`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     deleteApplication(app_name) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: `/v1/applications`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     addFanoutTrigger(app_name, trigger) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/fo-triggers`,
-                    {
-                        method: "POST",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                        body: JSON.stringify(trigger)
-                    })
-            );
-        }
+        return request(
+            {
+                method: "POST",
+                path: `/v1/applications/fo-triggers`,
+                body: trigger,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     editFanoutTrigger(app_name, trigger_id, trigger) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/fo-triggers/${trigger_id}`,
-                    {
-                        method: "PUT",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                        body: JSON.stringify(trigger)
-                    })
-            );
-        }
+        return request(
+            {
+                method: "PUT",
+                path: `/v1/applications/fo-triggers/${trigger_id}`,
+                body: trigger,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     deleteFanoutTrigger(app_name, trigger_id) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/fo-triggers/${trigger_id}`,
-                    {
-                        method: "DELETE",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "DELETE",
+                path: `/v1/applications/fo-triggers/${trigger_id}`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 
     listApplicationIndices(app_name) {
-        let fb = getFirebase();
-        if (fb) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(`${env.LEEK_API_URL}/v1/applications/${app_name}/indices`,
-                    {
-                        method: "GET",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json"
-                        },
-                    })
-            );
-        }
+        return request(
+            {
+                method: "GET",
+                path: `/v1/applications/indices`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 }

--- a/app/web/src/api/control.tsx
+++ b/app/web/src/api/control.tsx
@@ -1,6 +1,4 @@
-import getFirebase from "../utils/firebase";
-import env from "../utils/vars";
-import {Task, TaskFilters} from "./task";
+import {request} from "./request";
 
 export interface Control {
     retryTask(
@@ -14,22 +12,14 @@ export class ControlService implements Control {
         app_name: string,
         task_uuid: string,
     ) {
-        let fb = getFirebase();
-        if (fb && fb.auth().currentUser) {
-            return fb.auth().currentUser.getIdToken().then(token =>
-                fetch(
-                    `${env.LEEK_API_URL}/v1/control/tasks/${task_uuid}/retry`,
-                    {
-                        method: "POST",
-                        headers: {
-                            "Authorization": `Bearer ${token}`,
-                            "Content-Type": "application/json",
-                            "x-leek-app-name": app_name
-                        },
-                        body: JSON.stringify({})
-                    }
-                )
-            );
-        } else return Promise.reject("unauthenticated")
+        return request(
+            {
+                method: "POST",
+                path: `/v1/control/tasks/${task_uuid}/retry`,
+                headers: {
+                    "x-leek-app-name": app_name
+                }
+            }
+        )
     }
 }

--- a/app/web/src/api/request.tsx
+++ b/app/web/src/api/request.tsx
@@ -1,0 +1,46 @@
+import getFirebase from "../utils/firebase";
+import env from "../utils/vars";
+
+export function request(
+    {
+        method = "GET",
+        path = "/",
+        body = undefined,
+        headers = {},
+    }
+) {
+    // NO-AUTH
+    if (env.LEEK_API_ENABLE_AUTH !== "true") {
+        return fetch(
+            `${env.LEEK_API_URL}${path}`,
+            {
+                method: method,
+                headers: {
+                    "Content-Type": "application/json",
+                    ...headers
+                },
+                body: body ? JSON.stringify(body) : undefined
+            }
+        )
+    }
+    // FIREBASE AUTH
+    else {
+        let fb = getFirebase();
+        if (fb && fb.auth().currentUser) {
+            return fb.auth().currentUser.getIdToken().then(token =>
+                fetch(
+                    `${env.LEEK_API_URL}${path}`,
+                    {
+                        method: method,
+                        headers: {
+                            "Authorization": `Bearer ${token}`,
+                            "Content-Type": "application/json",
+                            ...headers
+                        },
+                        body: body ? JSON.stringify(body) : undefined
+                    }
+                )
+            );
+        } else return Promise.reject("unauthenticated")
+    }
+}

--- a/app/web/src/api/search.tsx
+++ b/app/web/src/api/search.tsx
@@ -1,5 +1,4 @@
-import getFirebase from "../utils/firebase";
-import env from "../utils/vars";
+import {request} from "./request";
 
 export function buildQueryString(obj: {}) {
     const keyValuePairs: string[] = [];
@@ -10,21 +9,14 @@ export function buildQueryString(obj: {}) {
 }
 
 export function search(app_name, query, params: {} = {}) {
-    let fb = getFirebase();
-    if (fb && fb.auth().currentUser) {
-        return fb.auth().currentUser.getIdToken().then(token =>
-            fetch(
-                `${env.LEEK_API_URL}/v1/search${buildQueryString(params)}`,
-                {
-                    method: "POST",
-                    headers: {
-                        "Authorization": `Bearer ${token}`,
-                        "Content-Type": "application/json",
-                        "x-leek-app-name": app_name
-                    },
-                    body: JSON.stringify(query)
-                }
-            )
-        );
-    } else return Promise.reject("unauthenticated")
+    return request(
+        {
+            method: "POST",
+            path: `/v1/search${buildQueryString(params)}`,
+            body: query,
+            headers: {
+                "x-leek-app-name": app_name,
+            },
+        }
+    )
 }

--- a/app/web/src/containers/apps/Applications.tsx
+++ b/app/web/src/containers/apps/Applications.tsx
@@ -43,13 +43,13 @@ const inferOrgName = () => {
         else
             return parts[1];
     }
-    return "org.com"
+    return "mono"
 };
 
 const agentSubscriptionsSnippet = (app) => {
     return `
     {
-        "${app.app_name}_prod": {
+        "${app.app_name}-prod": {
             "broker": "amqp://admin:admin@mq//",
             "backend": null,
             "exchange": "celeryev",

--- a/app/web/src/containers/layout/Header.tsx
+++ b/app/web/src/containers/layout/Header.tsx
@@ -10,6 +10,7 @@ import {
 import Image from "../../components/Image";
 import {useAuth} from "../../context/AuthProvider";
 import {useApplication} from "../../context/ApplicationProvider";
+import env from "../../utils/vars";
 
 const {SubMenu} = Menu;
 
@@ -175,11 +176,13 @@ const Header = () => {
                                     </a>
                                 </Col>
 
+                                {env.LEEK_API_ENABLE_AUTH === "true" &&
                                 <Col key="/logout" style={{float: 'right'}}>
                                     <Button size="small" danger onClick={logout} style={{textAlign: "center"}}>
                                         <LogoutOutlined/>
                                     </Button>
                                 </Col>
+                                }
                             </Row>
                         </Col>
                     </Row>

--- a/app/web/src/context/AuthProvider.tsx
+++ b/app/web/src/context/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react'
 import {Spin, message} from 'antd';
 
+import env from "../utils/vars";
 import getFirebase from '../utils/firebase';
 import Auth from '../containers/Auth'
 
@@ -25,8 +26,8 @@ function AuthProvider({children}) {
      *  gRPC Service Callbacks
      ---------------------- **/
     const [firebase, setFirebase] = useState();
-    const [loading, setLoading] = useState<boolean>(true);
-    const [bootstrapping, setBootstrapping] = useState<boolean>(true);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [bootstrapping, setBootstrapping] = useState<boolean>(false);
     const [user, setUser] = useState<any>(null);
 
 
@@ -65,6 +66,8 @@ function AuthProvider({children}) {
      *  Hooks
      ---------------------- */
     useEffect(() => {
+        if (env.LEEK_API_ENABLE_AUTH !== "true")
+            return
         setBootstrapping(true);
         setLoading(true);
         const fb = getFirebase();
@@ -86,7 +89,7 @@ function AuthProvider({children}) {
             }
         }>
             {
-                user ? children : bootstrapping ?
+                env.LEEK_API_ENABLE_AUTH !== "true" ? children : user ? children : bootstrapping ?
                     <Spin spinning={loading} size="large" style={{
                         width: "100%",
                         height: "100vh",

--- a/app/web/src/utils/firebase.tsx
+++ b/app/web/src/utils/firebase.tsx
@@ -13,6 +13,9 @@ const firebaseConfig = {
 let firebaseCache;
 
 const getFirebase = () => {
+    if (env.LEEK_API_ENABLE_AUTH !== "true")
+        return
+
     if (firebaseCache) {
         return firebaseCache
     }

--- a/app/web/src/utils/vars.tsx
+++ b/app/web/src/utils/vars.tsx
@@ -1,9 +1,12 @@
 let env = {
     "LEEK_API_URL": undefined,
+    "LEEK_API_ENABLE_AUTH": "true",
     "LEEK_FIREBASE_API_KEY": undefined,
     "LEEK_FIREBASE_AUTH_DOMAIN": undefined,
     "LEEK_FIREBASE_PROJECT_ID": undefined,
     "LEEK_FIREBASE_APP_ID": undefined,
 };
+
+console.log(window["leek_config"])
 
 export default typeof window !== 'undefined'?  window["leek_config"] : env;

--- a/app/web/static/leek-config.js
+++ b/app/web/static/leek-config.js
@@ -1,7 +1,4 @@
 window.leek_config = {
     "LEEK_API_URL": "http://0.0.0.0:5000",
-    "LEEK_FIREBASE_API_KEY": "AIzaSyBiv9xF6VjDsv62ufzUb9aFJUreHQaFoDk",
-    "LEEK_FIREBASE_AUTH_DOMAIN": "kodhive-leek.firebaseapp.com",
-    "LEEK_FIREBASE_PROJECT_ID": "kodhive-leek",
-    "LEEK_FIREBASE_APP_ID": "1:894368938723:web:e14677d1835ce9bd09e3d6",
+    "LEEK_API_ENABLE_AUTH": "false",
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,7 @@ services:
       - LEEK_WEB_URL=http://0.0.0.0:8000
       - LEEK_ES_URL=http://es01:9200
       # Authentication
-      - LEEK_FIREBASE_PROJECT_ID=kodhive-leek
-      - LEEK_FIREBASE_APP_ID=1:894368938723:web:e14677d1835ce9bd09e3d6
-      - LEEK_FIREBASE_API_KEY=AIzaSyBiv9xF6VjDsv62ufzUb9aFJUreHQaFoDk
-      - LEEK_FIREBASE_AUTH_DOMAIN=kodhive-leek.firebaseapp.com
-      # Authorization
-      - LEEK_API_OWNER_ORG=ramp.com
-      - LEEK_API_WHITELISTED_ORGS=ramp.com,
+      - LEEK_API_ENABLE_AUTH=false
       # Subscriptions
       - |
         LEEK_AGENT_SUBSCRIPTIONS=
@@ -37,7 +31,7 @@ services:
             "exchange": "celeryev",
             "queue": "leek.fanout",
             "routing_key": "#",
-            "org_name": "ramp.com",
+            "org_name": "mono",
             "app_name": "leek",
             "app_env": "prod",
             "prefetch_count": 1000,


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Related issue > https://github.com/kodless/leek/issues/11

Currently leek API only supports authenticated requests using Firebase, this can be challenging for:
- Users want to setup leek just for demo and want to avoid firebase setup hustle. 
- Users want to deploy leek inside VPC and not interested in authentication/authorization.

### What is the new behavior (if this is a feature change)?

Authentication/Authorization can be disable/enabled using `LEEK_API_ENABLE_AUTH` env variable.

- If `LEEK_API_ENABLE_AUTH` is set to `false` there will be no authentication/authorization and anyone who has access to leek can delete applications, purge applications ... because there is no user context and leek can't decide the owner of the application.

- If `LEEK_API_ENABLE_AUTH` is set to `true` authentication/authorization will be enforced, and user should be authenticated before start using leek and some actions will require the user to be an app owner.

- When disabling auth, no need to set these env variables:
      - `LEEK_FIREBASE_PROJECT_ID`
      - `LEEK_FIREBASE_APP_ID`
      - `LEEK_FIREBASE_API_KEY`
      - `LEEK_FIREBASE_AUTH_DOMAIN`
      - `LEEK_API_OWNER_ORG`
      - `LEEK_API_WHITELISTED_ORGS`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, for backward compatibility, `LEEK_API_ENABLE_AUTH` is set to `true`

If authentication is disabled, the `org_name` will be defaulted to `mono`

### Other information

Documentation will be updated soon, there will also be docker-compose.yml for no-auth demo
