### PR TITLE
Control: tasks revocation

### DIFF
--- a/app/leek/api/conf/settings.py
+++ b/app/leek/api/conf/settings.py
@@ -25,3 +25,6 @@ LEEK_API_URL = "http://0.0.0.0:5000"
 LEEK_WEB_URL = os.environ["LEEK_WEB_URL"]
 LEEK_AGENT_API_SECRET = os.environ.get("LEEK_AGENT_API_SECRET", str(uuid.uuid4()))
 LEEK_ENABLE_AGENT = get_bool("LEEK_ENABLE_AGENT")
+
+# Control
+LEEK_CONTROL_EXCHANGE_NAME = os.environ.get("LEEK_CONTROL_EXCHANGE_NAME", "celery")

--- a/app/leek/api/control/task.py
+++ b/app/leek/api/control/task.py
@@ -1,19 +1,50 @@
 import ast
 import logging
+import signal
 import time
+from typing import Union, List
 
 from kombu.utils.uuid import uuid
-from kombu import Connection
+from kombu import Connection, Exchange
 from amqp import AccessRefused
 
 from leek.api.conf import settings
+from leek.api.db.store import STATES_TERMINAL
 from leek.api.errors import responses
 from leek.api.control.utils import get_subscription
 
 logger = logging.getLogger(__name__)
 
 
+def get_control_exchange():
+    return Exchange(f'{settings.LEEK_CONTROL_EXCHANGE_NAME}.pidbox',
+                    type='fanout',
+                    durable=False,
+                    delivery_mode='transient')
+
+
+def broadcast_worker_command(command, arguments, producer):
+    message = {"method": command,
+               "arguments": arguments,
+               "destination": None,
+               "pattern": None,
+               "matcher": None}
+    exchange = get_control_exchange()
+    producer.publish(
+        message, exchange=exchange.name, declare=[exchange],
+        headers={
+            "clock": 1,
+            "expires": 300  # 5 minutes, before an unused remote control command queue is deleted from the broker
+        },
+        serializer="json",
+        retry=True,
+    )
+
+
 def retry_task(app_name, task_doc):
+    if task_doc.get("state") not in STATES_TERMINAL:
+        return responses.task_retry_state_precondition_failed
+
     # Check if task is routable
     if not task_doc.get("exchange", "tasks") and not task_doc.get("routing_key"):
         return responses.task_not_routable
@@ -86,17 +117,21 @@ def retry_task(app_name, task_doc):
         },
     )
     # Queue actual task
-    producer.publish(
-        body,
-        exchange=task_doc["exchange"],
-        routing_key=task_doc["routing_key"],
-        serializer="json",
-        compression=None,
-        retry=False,
-        delivery_mode=2,  # Persistent
-        headers=headers,
-        **properties
-    )
+    try:
+        producer.publish(
+            body,
+            exchange=task_doc["exchange"],
+            routing_key=task_doc["routing_key"],
+            serializer="json",
+            compression=None,
+            retry=False,
+            delivery_mode=2,  # Persistent
+            headers=headers,
+            **properties
+        )
+    except Exception as ex:
+        logger.error(ex)
+        return responses.task_retry_failed
     # Send task-sent event
     sent_event = {
         "type": "task-sent",
@@ -136,3 +171,41 @@ def retry_task(app_name, task_doc):
         logger.warning(f"Failed to send `task-sent` event for the retried task! with exception: {ex}")
     connection.release()
     return {"task_id": task_id}, 200
+
+
+def revoke(app_name, app_env, task_uuid: Union[str, List[str]], args):
+    # Check if agent is local
+    if not settings.LEEK_ENABLE_AGENT:
+        return responses.control_operations_not_supported
+
+    # Retrieve subscription
+    subscription = get_subscription(f"{app_name}-{app_env}")
+    if subscription is None:
+        return responses.task_retry_subscription_not_found
+
+    # Prepare connection/producer
+    # noinspection PyBroadException
+    try:
+        connection = Connection(subscription["broker"])
+        connection.ensure_connection(max_retries=2)
+        producer = connection.Producer()
+    except AccessRefused:
+        return responses.wrong_access_refused
+    except Exception:
+        return responses.broker_not_reachable
+
+    arguments = {
+        "task_id": task_uuid,
+        **args,
+    }
+
+    # noinspection PyBroadException
+    try:
+        broadcast_worker_command("revoke", arguments, producer)
+    except Exception as ex:
+        logger.error(ex)
+        return responses.task_revocation_failed
+    connection.release()
+
+    revocation_count = len(task_uuid) if isinstance(task_uuid, List) else 1
+    return {"acknowledged": True, "revocation_count": revocation_count}, 200

--- a/app/leek/api/db/search.py
+++ b/app/leek/api/db/search.py
@@ -1,6 +1,8 @@
 import time
 from elasticsearch import exceptions as es_exceptions
+from elasticsearch.helpers import scan
 
+from leek.api.db.store import STATES_UNREADY
 from leek.api.errors import responses
 from leek.api.ext import es
 
@@ -21,3 +23,30 @@ def search_index(index_alias, query, params):
 def get_task_by_uuid(index_alias, task_uuid):
     connection = es.connection
     return connection.get(index=index_alias, id=task_uuid)
+
+
+def get_revocable_tasks_by_name(index_alias, app_env, task_name):
+    tasks = []
+    connection = es.connection
+    body = {
+        "query": {
+            "bool": {
+                "must": [
+                    {"match": {"app_env": app_env}},
+                    {"match": {"name": task_name}},
+                    {"terms": {"state": list(STATES_UNREADY)}},
+                ]
+            }
+        }
+    }
+    resp = scan(
+        connection,
+        index=index_alias,
+        query=body,
+        _source=False,
+        scroll="1m",
+        size=1000
+    )
+    for _, task in enumerate(resp):
+        tasks.append(task["_id"])
+    return tasks

--- a/app/leek/api/decorators.py
+++ b/app/leek/api/decorators.py
@@ -45,6 +45,7 @@ def auth(_route=None, allowed_org_names: List = None, only_app_owner=False):
         @wraps(route)
         def wrapper(*args, **kwargs):
             g.app_name = request.headers.get("x-leek-app-name")
+            g.app_env = request.headers.get("x-leek-app-env")
             if settings.LEEK_API_ENABLE_AUTH:
                 get_claims()
                 if len(settings.LEEK_API_WHITELISTED_ORGS) and g.org_name not in settings.LEEK_API_WHITELISTED_ORGS:

--- a/app/leek/api/errors/responses.py
+++ b/app/leek/api/errors/responses.py
@@ -1,3 +1,19 @@
+task_retry_failed = {
+                                "error": {
+                                    "code": "500001",
+                                    "message": "Task retry failed",
+                                    "reason": "Task retry could not queued!"
+                                }
+                            }, 500
+
+task_revocation_failed = {
+                                "error": {
+                                    "code": "500002",
+                                    "message": "Task revocation failed",
+                                    "reason": "Task revocation command could not be queued"
+                                }
+                            }, 500
+
 cache_backend_unavailable = {
                                 "error": {
                                     "code": "503001",
@@ -5,6 +21,14 @@ cache_backend_unavailable = {
                                     "reason": "Cache backend unavailable"
                                 }
                             }, 503
+
+broker_not_reachable = {
+                           "error": {
+                               "code": "503002",
+                               "message": "Agent error",
+                               "reason": "Broker not reachable, check your network firewall!"
+                           }
+                       }, 503
 
 application_already_exist = {
                                 "error": {
@@ -62,21 +86,21 @@ no_subscriptions_found = {
                          }, 400
 
 malformed_args_or_kwarg_repr = {
-                               "error": {
-                                   "code": "400004",
-                                   "message": "Malformed args or kwargs",
-                                   "reason": "In order for the apply to work, please make sure the args/kwargs "
-                                             "are not truncated by increasing resultrepr_maxsize"
-                               }
-                           }, 400
-
-control_operations_not_supported = {
                                    "error": {
-                                       "code": "400005",
-                                       "message": "Operation not supported",
-                                       "reason": "Control operations available only if agent is local"
+                                       "code": "400004",
+                                       "message": "Malformed args or kwargs",
+                                       "reason": "In order for the apply to work, please make sure the args/kwargs "
+                                                 "are not truncated by increasing resultrepr_maxsize"
                                    }
                                }, 400
+
+control_operations_not_supported = {
+                                       "error": {
+                                           "code": "400005",
+                                           "message": "Operation not supported",
+                                           "reason": "Control operations available only if agent is local"
+                                       }
+                                   }, 400
 
 task_not_routable = {
                         "error": {
@@ -85,14 +109,6 @@ task_not_routable = {
                             "reason": "Task does not have a routing key"
                         }
                     }, 400
-
-broker_not_reachable = {
-                           "error": {
-                               "code": "503002",
-                               "message": "Agent error",
-                               "reason": "Broker not reachable, check your network firewall!"
-                           }
-                       }, 503
 
 wrong_access_refused = {
                            "error": {
@@ -109,3 +125,19 @@ subscription_already_exist = {
                                      "reason": "A subscription with the same name already exist"
                                  }
                              }, 412
+
+task_retry_state_precondition_failed = {
+                                           "error": {
+                                               "code": "412003",
+                                               "message": "Task not retryable",
+                                               "reason": "Only tasks in terminal state can be retried"
+                                           }
+                                       }, 412
+
+task_revoke_state_precondition_failed = {
+                                            "error": {
+                                                "code": "412004",
+                                                "message": "Task(s) not revocable",
+                                                "reason": "Only tasks not in terminal state can be revoke"
+                                            }
+                                        }, 412

--- a/app/leek/api/routes/control.py
+++ b/app/leek/api/routes/control.py
@@ -1,14 +1,16 @@
 import logging
 
-from flask import Blueprint, g
+from flask import Blueprint, g, request
 from flask_restx import Resource
 from elasticsearch import exceptions as es_exceptions
 
+from leek.api.db.store import STATES_TERMINAL
 from leek.api.decorators import auth
 from leek.api.db import search
 from leek.api.routes.api_v1 import api_v1
 from leek.api.control import task
 from leek.api.errors import responses
+from leek.api.schemas.control import RevocationSchema
 
 control_bp = Blueprint('control', __name__, url_prefix='/v1/control')
 control_ns = api_v1.namespace('control', 'Celery controlLer')
@@ -35,3 +37,62 @@ class TaskRetry(Resource):
         except es_exceptions.NotFoundError:
             return responses.application_not_found
 
+
+@control_ns.route('/tasks/<string:task_uuid>/revoke-by-id')
+class RevokeTaskByID(Resource):
+
+    @auth
+    def post(self, task_uuid):
+        """
+        Revoke a celery task
+        """
+        try:
+            args = request.get_json()
+            args = RevocationSchema.validate(args)
+            task_doc = search.get_task_by_uuid(
+                index_alias=g.index_alias,
+                task_uuid=task_uuid
+            )
+            t = task_doc["_source"]
+            # Check if task is revocable
+            if t.get("state") in STATES_TERMINAL:
+                return responses.task_revoke_state_precondition_failed
+            # Send revocation command
+            return task.revoke(g.app_name, t["app_env"], t["uuid"], args)
+        except es_exceptions.ConnectionError:
+            return responses.cache_backend_unavailable
+        except es_exceptions.NotFoundError:
+            return responses.application_not_found
+
+
+@control_ns.route('/tasks/<string:task_name>/revoke-by-name')
+class RevokeTaskByName(Resource):
+
+    @auth
+    def post(self, task_name):
+        """
+        Revoke a celery task
+        """
+        try:
+            args = request.get_json()
+            args = RevocationSchema.validate(args)
+            revocable_tasks = search.get_revocable_tasks_by_name(
+                index_alias=g.index_alias,
+                app_env=g.app_env,
+                task_name=task_name
+            )
+            # No revocable task found
+            if not len(revocable_tasks):
+                return responses.task_revoke_state_precondition_failed
+
+            # Dry run
+            params = request.args.to_dict()
+            if params.get("dry_run") == "true":
+                return {"revocation_count": len(revocable_tasks)}
+
+            # Send revocation command
+            return task.revoke(g.app_name, g.app_env, revocable_tasks, args)
+        except es_exceptions.ConnectionError:
+            return responses.cache_backend_unavailable
+        except es_exceptions.NotFoundError:
+            return responses.application_not_found

--- a/app/leek/api/schemas/control.py
+++ b/app/leek/api/schemas/control.py
@@ -1,0 +1,6 @@
+from schema import Schema, And, Optional, Or
+
+RevocationSchema = Schema({
+    Optional("terminate", default=False): And(bool),
+    Optional("signal", default="SIGTERM"): Or("SIGTERM", "SIGKILL"),
+})

--- a/app/web/src/api/application.tsx
+++ b/app/web/src/api/application.tsx
@@ -1,5 +1,4 @@
-import {buildQueryString} from "./search";
-import {request} from "./request";
+import {buildQueryString, request} from "./request";
 
 export interface Application {
     listApplications(): any;

--- a/app/web/src/api/control.tsx
+++ b/app/web/src/api/control.tsx
@@ -1,9 +1,23 @@
-import {request} from "./request";
+import {buildQueryString, request} from "./request";
 
 export interface Control {
     retryTask(
         app_name: string,
         task_uuid: string,
+    ): any;
+    revokeTaskByID(
+        app_name: string,
+        task_uuid: string,
+        terminate: boolean,
+        signal: string
+    ): any;
+    revokeTasksByName(
+        app_name: string,
+        app_env: string,
+        task_name: string,
+        terminate: boolean,
+        signal: string,
+        dry_run: string,
     ): any;
 }
 
@@ -18,6 +32,51 @@ export class ControlService implements Control {
                 path: `/v1/control/tasks/${task_uuid}/retry`,
                 headers: {
                     "x-leek-app-name": app_name
+                }
+            }
+        )
+    }
+    revokeTaskByID(
+        app_name: string,
+        task_uuid: string,
+        terminate: boolean,
+        signal: string
+    ) {
+        return request(
+            {
+                method: "POST",
+                path: `/v1/control/tasks/${task_uuid}/revoke-by-id`,
+                headers: {
+                    "x-leek-app-name": app_name
+                },
+                // @ts-ignore
+                body: {
+                    "terminate": terminate,
+                    "signal": signal
+                }
+            }
+        )
+    }
+    revokeTasksByName(
+        app_name: string,
+        app_env: string,
+        task_name: string,
+        terminate: boolean,
+        signal: string,
+        dry_run: string,
+    ) {
+        return request(
+            {
+                method: "POST",
+                path: `/v1/control/tasks/${task_name}/revoke-by-name${buildQueryString({"dry_run": dry_run})}`,
+                headers: {
+                    "x-leek-app-name": app_name,
+                    "x-leek-app-env": app_env
+                },
+                // @ts-ignore
+                body: {
+                    "terminate": terminate,
+                    "signal": signal
                 }
             }
         )

--- a/app/web/src/api/request.tsx
+++ b/app/web/src/api/request.tsx
@@ -1,6 +1,15 @@
 import getFirebase from "../utils/firebase";
 import env from "../utils/vars";
 
+
+export function buildQueryString(obj: {}) {
+    const keyValuePairs: string[] = [];
+    for (const key in obj) {
+        keyValuePairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`);
+    }
+    return `?${keyValuePairs.join('&')}`;
+}
+
 export function request(
     {
         method = "GET",

--- a/app/web/src/api/search.tsx
+++ b/app/web/src/api/search.tsx
@@ -1,12 +1,4 @@
-import {request} from "./request";
-
-export function buildQueryString(obj: {}) {
-    const keyValuePairs: string[] = [];
-    for (const key in obj) {
-        keyValuePairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`);
-    }
-    return `?${keyValuePairs.join('&')}`;
-}
+import {buildQueryString, request} from "./request";
 
 export function search(app_name, query, params: {} = {}) {
     return request(

--- a/app/web/src/components/filters/TaskAttributesFilter.tsx
+++ b/app/web/src/components/filters/TaskAttributesFilter.tsx
@@ -1,31 +1,12 @@
 import React, {useMemo} from "react";
-import {Card, Input, Row, Select, Button, Form, Badge, InputNumber, Col} from "antd";
+import {Card, Input, Row, Select, Button, Form, InputNumber} from "antd";
 
 import {useApplication} from "../../context/ApplicationProvider";
 import {TaskStateClosable} from "../tags/TaskState";
+import {badgedOption} from "../tags/BadgedOption";
 
 const {Option} = Select;
 const FormItem = Form.Item;
-const overflowCount = 999999;
-
-let badgeStyle = {
-    backgroundColor: "#00BFA6",
-    color: "#333",
-    fontWeight: 600
-};
-
-const badgedOption = (item) => {
-    return (<Option key={item.key} value={item.key}>
-        <Row style={{width: "100%"}} justify="space-between">
-            <Col>
-                {item.key}
-            </Col>
-            <Col>
-                <Badge count={item.doc_count} overflowCount={overflowCount} size="small" style={badgeStyle}/>
-            </Col>
-        </Row>
-    </Option>)
-};
 
 interface TasksFilterContextData {
     onFilter(value: {});

--- a/app/web/src/components/tags/BadgedOption.tsx
+++ b/app/web/src/components/tags/BadgedOption.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Badge, Col, Row, Select} from "antd";
+
+
+const Option = Select.Option;
+const overflowCount = 999999;
+const badgeStyle = {
+    backgroundColor: "#00BFA6",
+    color: "#333",
+    fontWeight: 600
+};
+
+export const badgedOption = (item) => {
+    return (
+        <Option key={item.key} value={item.key}>
+            <Row style={{width: "100%"}} justify="space-between">
+                <Col>
+                    {item.key}
+                </Col>
+                <Col>
+                    <Badge count={item.doc_count} overflowCount={overflowCount} size="small" style={badgeStyle}/>
+                </Col>
+            </Row>
+        </Option>
+    );
+};

--- a/app/web/src/containers/layout/Header.tsx
+++ b/app/web/src/containers/layout/Header.tsx
@@ -4,7 +4,7 @@ import {Menu, Layout, Button, Dropdown, Col, Row} from 'antd'
 import {Location} from '@reach/router';
 import {
     RobotFilled, UnorderedListOutlined, RadarChartOutlined, LogoutOutlined, BoxPlotOutlined,
-    ClearOutlined, DownOutlined, MenuOutlined, BugOutlined, DeploymentUnitOutlined
+    ClearOutlined, DownOutlined, MenuOutlined, BugOutlined, DeploymentUnitOutlined, ControlOutlined
 } from '@ant-design/icons';
 
 import Image from "../../components/Image";
@@ -54,6 +54,13 @@ const Header = () => {
             <Link to="/tasks">
                 <UnorderedListOutlined/>
                 Tasks
+            </Link>
+        </Menu.Item>,
+
+        <Menu.Item key="/control">
+            <Link to="/control">
+                <ControlOutlined />
+                Control
             </Link>
         </Menu.Item>,
 

--- a/app/web/src/containers/tasks/TaskDetails.tsx
+++ b/app/web/src/containers/tasks/TaskDetails.tsx
@@ -1,5 +1,22 @@
 import React, {useState} from 'react';
-import {Typography, Tabs, List, Row, Col, Tag, message, Space, Button, Modal, Spin} from 'antd';
+import {
+    Typography,
+    Tabs,
+    List,
+    Row,
+    Col,
+    Tag,
+    message,
+    Space,
+    Button,
+    Modal,
+    Spin,
+    Form,
+    Select,
+    Input,
+    InputNumber,
+    Checkbox
+} from 'antd';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import {atelierCaveDark} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
@@ -15,12 +32,17 @@ const Text = Typography.Text;
 const {TabPane} = Tabs;
 
 const {confirm} = Modal;
+const FormItem = Form.Item;
+const Option = Select.Option;
+const TerminalStates = ["SUCCEEDED", "FAILED", "REJECTED", "REVOKED", "RECOVERED", "CRITICAL"];
 
 export default props => {
 
     const {currentApp} = useApplication();
     const service = new ControlService();
     const [retrying, setRetrying] = useState<boolean>();
+    const [revoking, setRevoking] = useState<boolean>();
+    const [isRevokeModalVisible, setIsRevokeModalVisible] = useState(false);
 
 
     function retry() {
@@ -41,7 +63,8 @@ export default props => {
             icon: <ExclamationCircleOutlined/>,
             content: <>
                 <Typography.Paragraph>Task retry is an experimental feature for now!</Typography.Paragraph>
-                <Typography.Paragraph>Tasks part of chains, groups or chords will not be retried as part of them!</Typography.Paragraph>
+                <Typography.Paragraph>Tasks part of chains, groups or chords will not be retried as part of
+                    them!</Typography.Paragraph>
             </>,
             onOk: () => {
                 return retry()
@@ -56,10 +79,11 @@ export default props => {
             title: "Task retried!",
             icon: <CheckCircleOutlined style={{color: "#00BFA6"}}/>,
             content: <>
-                <Typography.Paragraph>Task retried successfully with uuid <Typography.Text code>{task_id}</Typography.Text></Typography.Paragraph>
+                <Typography.Paragraph>Task retried successfully with uuid <Typography.Text
+                    code>{task_id}</Typography.Text></Typography.Paragraph>
             </>,
             onOk: () => {
-                window.open(`/task?app=${currentApp}&uuid=${task_id}`,"_self")
+                window.open(`/task?app=${currentApp}&uuid=${task_id}`, "_self")
             },
             onCancel: () => {
                 window.open(`/task?app=${currentApp}&uuid=${task_id}`, "_blank")
@@ -69,16 +93,89 @@ export default props => {
         });
     }
 
+    function revoke(args) {
+        console.log(args);
+        if (!currentApp) return;
+        setRevoking(true);
+        return service.revokeTaskByID(currentApp, props.task.uuid, args.terminate, args.signal)
+            .then(handleAPIResponse)
+            .then((result: any) => {
+                setIsRevokeModalVisible(false);
+                pendingRevocation()
+            }, handleAPIError)
+            .catch(handleAPIError)
+            .finally(() => setRevoking(false));
+    }
+
+    function pendingRevocation() {
+        confirm({
+            title: "Task pending revocation!",
+            icon: <CheckCircleOutlined style={{color: "#00BFA6"}}/>,
+            content: <>
+                <Typography.Paragraph>Task revocation command queued!</Typography.Paragraph>
+            </>,
+            okText: "Ok",
+            cancelButtonProps: {style: {display: 'none'}}
+        });
+    }
+
     return (
         <TaskDetails>
+            <Modal
+                title={
+                    <><ExclamationCircleOutlined style={{color: "#d89614"}}/> Do you really want to revoke this task?</>
+                }
+                footer={[
+                    <Button form="revokeForm" key="submit" htmlType="submit" loading={revoking}>
+                        Revoke
+                    </Button>
+                ]}
+                onCancel={() => setIsRevokeModalVisible(false)}
+                visible={isRevokeModalVisible}
+            >
+                <Form id="revokeForm" onFinish={revoke}
+                      initialValues={{terminate: false, signal: "SIGTERM"}}
+                      style={{marginTop: 10}}
+                >
+                    <Typography.Paragraph>
+                        Revoking tasks works by sending a broadcast message to all the workers, the workers then keep a
+                        list of revoked tasks in memory. When a worker receives a task in the list, it will skip
+                        executing the task, but it won’t terminate an already executing task unless the terminate option
+                        is set.</Typography.Paragraph>
+
+                    <Input.Group compact style={{marginTop: 16}}>
+                        <FormItem name="terminate" valuePropName="checked">
+                            <Checkbox>Terminate if started with</Checkbox>
+                        </FormItem>
+                        <FormItem name="signal">
+                            <Select style={{width: 100}}>
+                                <Option value="SIGTERM">SIGTERM</Option>
+                                <Option value="SIGKILL">SIGKILL</Option>
+                            </Select>
+                        </FormItem>
+                    </Input.Group>
+
+                    <Typography.Text type="secondary">
+                        When a worker starts up it will synchronize revoked tasks with other workers in the cluster.
+                        However, if The list of revoked tasks is in-memory and if all workers restart the list of
+                        revoked ids will also vanish. If you want to preserve this list between restarts you need to
+                        specify a file for these to be stored in by using the –statedb argument to celery worker.
+                    </Typography.Text>
+                </Form>
+            </Modal>
+
             {/* Header */}
 
             <Row justify="space-between">
                 <Col>{buildTag(props.task.state, props.task)} {adaptTime(props.task.timestamp)}</Col>
                 <Col>
                     <Space>
-                        { ["SUCCEEDED", "FAILED", "REJECTED", "REVOKED", "RECOVERED", "CRITICAL"].includes(props.task.state) &&
-                            <Button onClick={handleRetryTask} loading={retrying} ghost type="primary">Retry</Button>
+                        {!TerminalStates.includes(props.task.state) &&
+                        <Button onClick={() => setIsRevokeModalVisible(true)} loading={revoking} ghost
+                                danger>Revoke</Button>
+                        }
+                        {TerminalStates.includes(props.task.state) &&
+                        <Button onClick={handleRetryTask} loading={retrying} ghost type="primary">Retry</Button>
                         }
                         <Tag>{`${props.task.events_count} EVENTS`}</Tag>
                         <Text copyable={{text: window.location.href}} strong>LINK</Text>
@@ -89,7 +186,8 @@ export default props => {
             <Tabs defaultActiveKey="basic"
                   tabBarExtraContent={
                       props.loading !== undefined && <Space>
-                          <Typography.Text code> { props.loading ? <SyncOutlined spin />: <LoadingOutlined />} Refreshes every 5 seconds</Typography.Text>
+                          <Typography.Text code> {props.loading ? <SyncOutlined spin/> : <LoadingOutlined/>} Refreshes
+                              every 5 seconds</Typography.Text>
                       </Space>
                   }
             >

--- a/app/web/src/pages/control.tsx
+++ b/app/web/src/pages/control.tsx
@@ -1,0 +1,202 @@
+import React, {useMemo, useState} from 'react'
+import {Helmet} from 'react-helmet'
+import {Steps, Row, Button, Card, Select, Typography, Checkbox, Input, Modal} from 'antd';
+import {CheckCircleOutlined} from "@ant-design/icons";
+
+import {useApplication} from "../context/ApplicationProvider";
+import {ControlService} from "../api/control";
+import {handleAPIError, handleAPIResponse} from "../utils/errors";
+import {badgedOption} from "../components/tags/BadgedOption";
+import {TaskState} from "../components/tags/TaskState";
+
+const {Step} = Steps;
+const Option = Select.Option;
+const {confirm} = Modal;
+
+
+const ControlPage = () => {
+
+    const [current, setCurrent] = useState(0);
+    const [command, setCommand] = useState<string>("revoke");
+    const {seenTasks, currentApp, currentEnv} = useApplication();
+
+    const service = new ControlService();
+    const [broadcasting, setBroadcasting] = useState<boolean>();
+
+    const [taskName, setTaskName] = useState<string>();
+    const [terminate, setTerminate] = useState<boolean>(false);
+    const [signal, setSignal] = useState<string>("SIGTERM");
+    const [revocationCount, setRevocationCount] = useState<number>(0);
+
+
+    const next = () => {
+        if (command === "revoke" && current === 1)
+            revoke("true").then(() => {
+                setCurrent(current + 1);
+            })
+        else
+            setCurrent(current + 1);
+    };
+
+    const prev = () => {
+        setCurrent(current - 1);
+    };
+
+    const memoizedTaskNameOptions = useMemo(() => {
+        // memoize this because it's common to have many different task names, which causes the dropdown to be very laggy.
+        // This is a known problem in Ant Design
+        return seenTasks.map((task, key) => badgedOption(task))
+    }, [seenTasks])
+
+
+    function revoke(dry_run) {
+        if (!currentApp || !currentEnv || !taskName) return;
+        setBroadcasting(true);
+        return service.revokeTasksByName(currentApp, currentEnv, taskName, terminate, signal, dry_run)
+            .then(handleAPIResponse)
+            .then((result: any) => {
+                setRevocationCount(result.revocation_count);
+                if (dry_run !== "true") {
+                    setCurrent(0)
+                    pendingRevocation(result)
+                }
+            }, handleAPIError)
+            .catch(handleAPIError)
+            .finally(() => setBroadcasting(false));
+    }
+
+    function broadcastCommand() {
+        if (command === "revoke")
+            revoke("false")
+    }
+
+    function pendingRevocation(result) {
+        confirm({
+            title: "Tasks pending revocation!",
+            icon: <CheckCircleOutlined style={{color: "#00BFA6"}}/>,
+            content: <>
+                <Typography.Paragraph>Revocation command queued
+                    for {result.revocation_count} tasks!</Typography.Paragraph>
+            </>,
+            okText: "Ok",
+            cancelButtonProps: {style: {display: 'none'}}
+        });
+    }
+
+    return (
+        <>
+            <Helmet
+                title="Control"
+                meta={[
+                    {name: 'description', content: 'Control commands'},
+                    {name: 'keywords', content: 'celery, tasks'},
+                ]}
+            >
+                <html lang="en"/>
+            </Helmet>
+
+            {/* Steps */}
+            <Row style={{marginTop: 20}}>
+                <Card style={{width: "100%"}}>
+                    <Steps current={current}>
+                        <Step title="Command" description="Choose command"/>
+                        <Step title="Setup" description="Setup command args"/>
+                        <Step title="Broadcast" description="Broadcast command"/>
+                    </Steps>
+                </Card>
+            </Row>
+
+            {/* Tabs Containers */}
+            <Row style={{marginTop: 20, marginBottom: 20}}>
+                <Card style={{width: "100%", alignItems: "center"}}>
+                    {current == 0 && (
+                        <Row justify="center" style={{width: "100%"}}>
+                            <Row style={{width: "100%"}} justify="center">
+                                <Typography.Title level={5}>
+                                    What control command you want to broadcast?
+                                </Typography.Title>
+                            </Row>
+
+                            <Row style={{width: "100%"}} justify="center">
+                                <Select style={{width: "200"}} defaultValue="revoke"
+                                        onSelect={value => setCommand(value)}>
+                                    <Option value="revoke">Revoke</Option>
+                                </Select>
+                            </Row>
+                        </Row>
+                    )}
+
+                    {current == 1 && command === "revoke" && (
+                        <Row justify="center" style={{width: "100%"}}>
+                            <Select placeholder="Task name"
+                                    style={{width: "100%"}}
+                                    allowClear
+                                    showSearch
+                                    dropdownMatchSelectWidth={false}
+                                // @ts-ignore
+                                    onSelect={value => setTaskName(value)}
+                            >
+                                {memoizedTaskNameOptions}
+                            </Select>
+
+                            <Row align="middle" style={{marginTop: 16, width: "100%"}}>
+                                <Checkbox onChange={e => setTerminate(e.target.checked)}> Terminate already started
+                                    tasks with</Checkbox>
+                                <Select style={{width: 90}}
+                                    // @ts-ignore
+                                        onSelect={value => setSignal(value)}
+                                        defaultValue="SIGTERM"
+                                >
+                                    <Option value="SIGTERM">SIGTERM</Option>
+                                    <Option value="SIGKILL">SIGKILL</Option>
+                                </Select>
+                            </Row>
+                        </Row>
+                    )}
+
+                    {current == 2 && command === "revoke" && (
+                        <>
+                            <Row justify="center" style={{width: "100%"}}>
+                                <Typography.Paragraph>
+                                    Found <Typography.Text code>{revocationCount}</Typography.Text> pending (  <TaskState state="QUEUED"/> <TaskState state="RECEIVED"/> <TaskState state="STARTED"/>) instances of
+                                    task <Typography.Text code>{taskName}</Typography.Text>.
+                                    Are you sure you want to revoke them all?
+                                </Typography.Paragraph>
+                            </Row>
+                            {terminate &&
+                            <Row justify="center" style={{width: "100%"}}>
+                                <Typography.Paragraph type="secondary">
+                                    If an instance is already <TaskState state="STARTED"/> it will be terminated using <Typography.Text
+                                    code>{signal}</Typography.Text> signal!
+                                </Typography.Paragraph>
+                            </Row>
+                            }
+                        </>
+
+                    )}
+                </Card>
+            </Row>
+
+            {/* Controls */}
+            <Row justify="end">
+                {current > 0 && (
+                    <Button style={{margin: '0 8px'}} onClick={() => prev()}>
+                        Previous
+                    </Button>
+                )}
+                {current < 2 && (
+                    <Button type="primary" onClick={() => next()}>
+                        Next
+                    </Button>
+                )}
+                {current === 2 && (
+                    <Button type="primary" onClick={broadcastCommand} loading={broadcasting}>
+                        Broadcast
+                    </Button>
+                )}
+            </Row>
+        </>
+    )
+};
+
+export default ControlPage


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Tasks can't be revoked by leek

### What is the new behavior (if this is a feature change)?

Leek will be able to:
- Revoke a single task by ID
- Revoke all instances of a task by name

A dry run will be executed before broadcasting the revocation command, to return how many possible tasks will be revoked.

if you are using a different control exchange name than the default `celery`, you can provide that with `LEEK_CONTROL_EXCHANGE_NAME` env variable name.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information
<img width="1719" alt="Screen Shot 2021-07-07 at 14 41 19" src="https://user-images.githubusercontent.com/56397909/124776586-77bcf680-df37-11eb-875a-91d78d03747f.png">
<img width="1711" alt="Screen Shot 2021-07-07 at 14 42 12" src="https://user-images.githubusercontent.com/56397909/124776648-84d9e580-df37-11eb-903a-55ab1bf88242.png">
<img width="1710" alt="Screen Shot 2021-07-07 at 14 42 30" src="https://user-images.githubusercontent.com/56397909/124776697-8c998a00-df37-11eb-82fc-52a00473bbb4.png">
<img width="1717" alt="Screen Shot 2021-07-07 at 14 42 51" src="https://user-images.githubusercontent.com/56397909/124776728-93c09800-df37-11eb-9f1e-fd0faca0c521.png">

