### PR TITLE
setting default of missing worker commandmessage keys to None #29

### DIFF
--- a/app/leek/api/schemas/worker.py
+++ b/app/leek/api/schemas/worker.py
@@ -1,4 +1,4 @@
-from schema import Schema, And, Or
+from schema import Schema, And, Or, Optional
 
 WORKER_EVENT_TYPES = (
     "worker-online",
@@ -23,9 +23,9 @@ WorkerEventSchema = Schema(
         "pid": And(int),
         "clock": And(int),
         "freq": And(Or(float, int)),
-        "active": And(int),
-        "processed": And(int),
-        "loadavg": And(list),
+        Optional("active", default=None): And(int),
+        Optional('processed', default=None): And(int),
+        Optional('loadavg', default=None): And(list),
         "sw_ident": And(str),
         "sw_ver": And(str),
         "sw_sys": And(str),


### PR DESCRIPTION
For this issue #29 I have set defaults for the missing keys.
```python
WorkerEventSchema = Schema(
    {
        "type": Or(
            *WORKER_EVENT_TYPES
        ),
        "hostname": And(str, len),
        "timestamp": And(float,),
        "utcoffset": And(int),
        "pid": And(int),
        "clock": And(int),
        "freq": And(Or(float, int)),
        Optional("active", default=None): And(int),
        Optional('processed', default=None): And(int),
        Optional('loadavg', default=None): And(list),
        "sw_ident": And(str),
        "sw_ver": And(str),
        "sw_sys": And(str),
    }
)
```

Im using a default of None, because i have assumed that because of this
```groovy
    // Merge
    for (def entry : params.entrySet()) {
        if (entry.getValue() != null && attrs_to_upsert.contains(entry.getKey())) {
            ctx._source[entry.getKey()] = entry.getValue();
        }
    }
```

the value will be ignored and not merged, but would allow otherwise a normal processing of the control-command message.

