### PR TITLE
Aggregations enhancements part3

### DIFF
--- a/app/leek/api/conf/settings.py
+++ b/app/leek/api/conf/settings.py
@@ -12,6 +12,7 @@ def get_bool(env_name, default="false"):
 
 # ES
 LEEK_ES_URL = os.environ.get("LEEK_ES_URL")
+LEEK_ES_DEFAULT_REFRESH_INTERVAL = os.environ.get("LEEK_ES_DEFAULT_REFRESH_INTERVAL", "20s")
 
 # Authentication/Authorization
 LEEK_API_ENABLE_AUTH = get_bool("LEEK_API_ENABLE_AUTH", "true")

--- a/app/leek/api/db/template.py
+++ b/app/leek/api/db/template.py
@@ -3,6 +3,7 @@ import time
 
 from elasticsearch import exceptions as es_exceptions
 
+from leek.api.conf import settings
 from leek.api.ext import es
 from leek.api.errors import responses
 from leek.api.db.properties import properties
@@ -18,6 +19,7 @@ def prepare_template_body(index_alias, lifecycle_policy_name="default", meta=Non
                 "index": {
                     "number_of_shards": "1",
                     "number_of_replicas": "0",
+                    "refresh_interval": settings.LEEK_ES_DEFAULT_REFRESH_INTERVAL
                 },
                 # TODO: uncomment when ILM is supported by leek
                 # "index.lifecycle.name": lifecycle_policy_name,

--- a/app/web/src/components/filters/TaskAttributesFilter.tsx
+++ b/app/web/src/components/filters/TaskAttributesFilter.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo, useState} from "react";
-import {Card, Input, Row, Select, Button, Form, InputNumber, Col, Badge} from "antd";
+import {Card, Input, Row, Select, Button, Form, InputNumber, Spin} from "antd";
 
 import {useApplication} from "../../context/ApplicationProvider";
 import {TaskStateClosable} from "../tags/TaskState";
@@ -15,6 +15,8 @@ interface TasksFilterContextData {
     filters: any
 }
 
+const loadingIndicator = <Row justify="center" align="middle" style={{width: "100%"}}><Spin size="small"/></Row>;
+
 const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilterContextData) => {
     const {currentEnv, currentApp} = useApplication();
     const metricsService = new MetricsService();
@@ -24,6 +26,13 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
     const [seenRoutingKeys, setSeenRoutingKeys] = useState([]);
     const [seenQueues, setSeenQueues] = useState([]);
     const [seenWorkers, setSeenWorkers] = useState([]);
+
+    // Fetch progress
+    const [seenTasksFetching, setSeenTasksFetching] = useState<boolean>();
+    const [seenRoutingKeysFetching, setSeenRoutingKeysFetching] = useState<boolean>();
+    const [seenQueuesFetching, setSeenQueuesFetching] = useState<boolean>();
+    const [seenWorkersFetching, setSeenWorkersFetching] = useState<boolean>();
+
 
     // UI Callbacks
     function handleReset() {
@@ -37,42 +46,50 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
 
     function getSeenTasks(open) {
         if (!currentApp || !open) return;
+        setSeenTasksFetching(true);
         metricsService.getSeenTasks(currentApp, currentEnv, props.filters)
             .then(handleAPIResponse)
             .then((result: any) => {
                 setSeenTasks(result.aggregations.seen_tasks.buckets);
             }, handleAPIError)
-            .catch(handleAPIError);
+            .catch(handleAPIError)
+            .finally(() => setSeenTasksFetching(false));
     }
 
     function getSeenRoutingKeys(open) {
         if (!currentApp || !open) return;
+        setSeenRoutingKeysFetching(true);
         metricsService.getSeenRoutingKeys(currentApp, currentEnv, props.filters)
             .then(handleAPIResponse)
             .then((result: any) => {
                 setSeenRoutingKeys(result.aggregations.seen_routing_keys.buckets);
             }, handleAPIError)
-            .catch(handleAPIError);
+            .catch(handleAPIError)
+            .finally(() => setSeenRoutingKeysFetching(false));
     }
 
     function getSeenQueues(open) {
         if (!currentApp || !open) return;
+        setSeenQueuesFetching(true);
         metricsService.getSeenQueues(currentApp, currentEnv, props.filters)
             .then(handleAPIResponse)
             .then((result: any) => {
                 setSeenQueues(result.aggregations.seen_queues.buckets);
             }, handleAPIError)
-            .catch(handleAPIError);
+            .catch(handleAPIError)
+            .finally(() => setSeenQueuesFetching(false));
     }
 
     function getSeenWorkers(open) {
         if (!currentApp || !open) return;
+        setSeenWorkersFetching(true);
         metricsService.getSeenWorkers(currentApp, currentEnv, props.filters)
             .then(handleAPIResponse)
             .then((result: any) => {
                 setSeenWorkers(result.aggregations.seen_workers.buckets);
             }, handleAPIError)
-            .catch(handleAPIError);
+            .catch(handleAPIError)
+            .finally(() => setSeenWorkersFetching(false));
     }
 
 
@@ -107,6 +124,7 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
                                 showSearch
                                 dropdownMatchSelectWidth={false}
                                 onDropdownVisibleChange={getSeenTasks}
+                                notFoundContent={seenTasksFetching ? loadingIndicator : null}
                         >
                             {memoizedTaskNameOptions}
                         </Select>
@@ -137,6 +155,7 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
                         <Select placeholder="Routing key"
                                 mode="multiple"
                                 style={{width: "100%"}}
+                                notFoundContent={seenRoutingKeysFetching ? loadingIndicator : null}
                                 onDropdownVisibleChange={getSeenRoutingKeys}
                                 allowClear>
                             {
@@ -150,6 +169,7 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
                         <Select placeholder="Queue"
                                 mode="multiple"
                                 style={{width: "100%"}}
+                                notFoundContent={seenQueuesFetching ? loadingIndicator : null}
                                 onDropdownVisibleChange={getSeenQueues}
                                 allowClear>
                             {
@@ -163,6 +183,7 @@ const TaskAttributesFilter: React.FC<TasksFilterContextData> = (props: TasksFilt
                         <Select placeholder="Worker"
                                 mode="multiple"
                                 style={{width: "100%"}}
+                                notFoundContent={seenWorkersFetching ? loadingIndicator : null}
                                 onDropdownVisibleChange={getSeenWorkers}
                                 allowClear>
                             {

--- a/app/web/src/pages/control.tsx
+++ b/app/web/src/pages/control.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo, useState} from 'react'
 import {Helmet} from 'react-helmet'
-import {Steps, Row, Button, Card, Select, Typography, Checkbox, Modal, Divider} from 'antd';
+import {Steps, Row, Button, Card, Select, Typography, Checkbox, Modal, Divider, Spin} from 'antd';
 import {CheckCircleOutlined} from "@ant-design/icons";
 
 import {useApplication} from "../context/ApplicationProvider";
@@ -14,6 +14,7 @@ const {Step} = Steps;
 const Option = Select.Option;
 const {confirm} = Modal;
 
+const loadingIndicator = <Row justify="center" align="middle" style={{width: "100%"}}><Spin size="small"/></Row>;
 
 const ControlPage = () => {
 
@@ -30,6 +31,8 @@ const ControlPage = () => {
     const [terminate, setTerminate] = useState<boolean>(false);
     const [signal, setSignal] = useState<string>("SIGTERM");
     const [revocationCount, setRevocationCount] = useState<number>(0);
+
+    const [seenTasksFetching, setSeenTasksFetching] = useState<boolean>();
 
 
     const next = () => {
@@ -88,12 +91,14 @@ const ControlPage = () => {
 
     function getSeenTasks(open) {
         if (!currentApp || !open) return;
+        setSeenTasksFetching(true);
         metricsService.getSeenTasks(currentApp, currentEnv, {})
             .then(handleAPIResponse)
             .then((result: any) => {
                 setSeenTasks(result.aggregations.seen_tasks.buckets);
             }, handleAPIError)
-            .catch(handleAPIError);
+            .catch(handleAPIError)
+            .finally(() => setSeenTasksFetching(false));
     }
 
     return (
@@ -154,6 +159,7 @@ const ControlPage = () => {
                                     showSearch
                                     dropdownMatchSelectWidth={false}
                                     onDropdownVisibleChange={getSeenTasks}
+                                    notFoundContent={seenTasksFetching ? loadingIndicator : null}
                                     // @ts-ignore
                                     onSelect={value => setTaskName(value)}
                             >


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Enhancements

* **What is the current behavior?** (You can also link to an open issue here)

Refresh is an expensive operation and Elasticsearch by default refreshes indices every 1seconds.

* **What is the new behavior (if this is a feature change)?**

Optimize search/index speed by changing default refresh interval to 20s and give leek users ability to change that interval using env variable.

Warning: using high refresh interval will make leek loose near realtime feature because the tasks will be available for search only after refresh so if you set refresh interval to 5 minutes there will be a maximum of 5 minutes delay between when the event is indexed and when the event is visible for search.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, only newly created indices will be using this default refresh interval. if you want to update old indices you have to do that manually.
