### PR TITLE
Use keyword field for machine generated fields

### DIFF
--- a/app/leek/api/db/properties.py
+++ b/app/leek/api/db/properties.py
@@ -92,13 +92,13 @@ properties = {
         "format": "epoch_millis"
     },
     "args": {
-        "type": "wildcard",
+        "type": "keyword",
     },
     "kwargs": {
-        "type": "wildcard",
+        "type": "keyword",
     },
     "result": {
-        "type": "wildcard"
+        "type": "keyword"
     },
     "runtime": {
         "type": "double"
@@ -116,7 +116,7 @@ properties = {
         }
     },
     "traceback": {
-        "type": "wildcard"
+        "type": "keyword"
     },
     # Workers specific
     "hostname": {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

AWS OpenDistro Elasticsearch does not support wildcard field and Leek couldn't create application index.

* **What is the new behavior (if this is a feature change)?**

Use keyword field until AWS add support for wildcard field

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
