### PR TITLE
Fix max bytes length exceeded exception

### DIFF
--- a/app/leek/api/db/events.py
+++ b/app/leek/api/db/events.py
@@ -56,7 +56,7 @@ def merge_events(index_alias, events: Dict[str, Union[Task, Worker]]):
             try:
                 err = error["update"]["error"]["caused_by"]["type"]
                 if err in ignorable_errors:
-                    print(f"Ignore error: {err}")
+                    print(f"Payload caused an error {err} and leek did not index it!")
                     return [], 201
             except KeyError:
                 pass

--- a/app/leek/api/schemas/task.py
+++ b/app/leek/api/schemas/task.py
@@ -63,7 +63,7 @@ TaskEventSchema = Schema(
         Optional("retries"): And(int),
         # Only available with task-failed, task-retried
         Optional("exception"): And(str),
-        Optional("traceback"): And(str),
+        Optional("traceback"): And(str, Use(lambda t: t[:30000])),
         # Only available with task-revoked events
         Optional("terminated"): And(bool),
         Optional("expired"): And(bool),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Events with immense exception traceback cannot be indexed as ES terms bytes can be at most 32766 in length

* **What is the new behavior (if this is a feature change)?**

Trim longer traceback field to 30000bytes max

Ignore the error and acknowledge the event if another fields are causing this issue

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No