### PR TITLE
Show missed keys for subscription

### DIFF
--- a/app/bin/bootstrap.py
+++ b/app/bin/bootstrap.py
@@ -164,7 +164,7 @@ def validate_subscriptions(subs):
         ]
         keys = subscription.keys()
         if not all(required_key in keys for required_key in required_keys):
-            missed_keys = (key for key in required_keys if key not in keys)
+            missed_keys = ", ".join((key for key in required_keys if key not in keys))
             abort(f"Agent subscription configuration is invalid. Required keys are missed: {missed_keys}")
 
         if not (subscription["app_name"].isalpha() and subscription["app_name"].islower()):

--- a/app/bin/bootstrap.py
+++ b/app/bin/bootstrap.py
@@ -164,7 +164,8 @@ def validate_subscriptions(subs):
         ]
         keys = subscription.keys()
         if not all(required_key in keys for required_key in required_keys):
-            abort(f"Agent subscription configuration is invalid")
+            missed_keys = (key for key in required_keys if key not in keys)
+            abort(f"Agent subscription configuration is invalid. Required keys are missed: {missed_keys}")
 
         if not (subscription["app_name"].isalpha() and subscription["app_name"].islower()):
             abort(f"app_name value should be lowercase alphabetic string")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** 
Feature. When subscription configuration is missing any of required keys, there are no any hints how to fix it.
Moreover, there are no description of required keys at all.
This PR adds information about missed keys.

* **What is the current behavior?** (You can also link to an open issue here)
Currently there is only a message saying:

`ERROR:utils:Agent subscription configuration is invalid.`

* **What is the new behavior (if this is a feature change)?**

Now, missed keys are mentioned in logs:
`ERROR:utils:Agent subscription configuration is invalid. Required keys are missed: queue, routing_key`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
I haven't added any tests and docs because tests are missing, and docs doesn't describe required keys. However, feel free to ask me to add test or docs.
