### PR TITLE
Export filtered tasks

### DIFF
--- a/app/leek/api/backup/export.py
+++ b/app/leek/api/backup/export.py
@@ -1,0 +1,38 @@
+import logging
+
+from leek.api.ext import es
+
+logger = logging.getLogger(__name__)
+
+
+def export_by_query(index, query, scroll_size=1000, scroll_context="10s"):
+    body = {
+        "size": scroll_size,
+        "query": query
+    }
+    docs = []
+    connection = es.connection
+    response = connection.search(
+        index=index,
+        body=body,
+        scroll=scroll_context  # length of time to keep search context
+    )
+    # keep track of pass scroll _id
+    scroll_id = response["_scroll_id"]
+
+    # use a 'while' iterator to loop over document 'hits'
+    while len(response["hits"]["hits"]):
+        # make a request using the Scroll API
+        response = connection.scroll(
+            scroll_id=scroll_id,
+            scroll=scroll_context  # length of time to keep search context
+        )
+
+        # keep track of pass scroll _id
+        scroll_id = response["_scroll_id"]
+
+        # iterate over the document hits for each 'scroll'
+        for doc in response["hits"]["hits"]:
+            docs.append(doc["_source"])
+
+    return docs

--- a/app/leek/api/backup/export.py
+++ b/app/leek/api/backup/export.py
@@ -15,23 +15,19 @@ def export_by_query(index, query, scroll_size=1000, scroll_context="10s"):
     response = connection.search(
         index=index,
         body=body,
-        scroll=scroll_context  # length of time to keep search context
+        scroll=scroll_context
     )
-    # keep track of pass scroll _id
+    # keep track of past scroll _id
     scroll_id = response["_scroll_id"]
 
-    # use a 'while' iterator to loop over document 'hits'
     while len(response["hits"]["hits"]):
-        # make a request using the Scroll API
         response = connection.scroll(
             scroll_id=scroll_id,
-            scroll=scroll_context  # length of time to keep search context
+            scroll=scroll_context
         )
 
-        # keep track of pass scroll _id
         scroll_id = response["_scroll_id"]
 
-        # iterate over the document hits for each 'scroll'
         for doc in response["hits"]["hits"]:
             docs.append(doc["_source"])
 

--- a/app/leek/api/blueprints.py
+++ b/app/leek/api/blueprints.py
@@ -6,6 +6,7 @@ from leek.api.routes.events import events_bp
 from leek.api.routes.search import search_bp
 from leek.api.routes.agent import agent_bp
 from leek.api.routes.control import control_bp
+from leek.api.routes.backup import backup_bp
 
 
 def register_blueprints(app):
@@ -18,3 +19,4 @@ def register_blueprints(app):
     app.register_blueprint(search_bp)
     app.register_blueprint(agent_bp)
     app.register_blueprint(control_bp)
+    app.register_blueprint(backup_bp)

--- a/app/leek/api/ext/__init__.py
+++ b/app/leek/api/ext/__init__.py
@@ -2,5 +2,5 @@ from flask_cors import CORS
 
 from .es import ESExtension
 
-cors = CORS()
+cors = CORS(expose_headers=["Content-Disposition"])
 es = ESExtension()

--- a/app/leek/api/routes/backup.py
+++ b/app/leek/api/routes/backup.py
@@ -1,0 +1,52 @@
+import json
+import logging
+import tempfile
+from datetime import datetime
+
+from flask import Blueprint, g, request, send_file
+from flask_restx import Resource
+from elasticsearch import exceptions as es_exceptions
+
+from leek.api.decorators import auth
+from leek.api.routes.api_v1 import api_v1
+from leek.api.errors import responses
+from leek.api.backup.export import export_by_query
+
+backup_bp = Blueprint('backup', __name__, url_prefix='/v1/backup')
+backup_ns = api_v1.namespace('backup', 'Leek backup')
+
+logger = logging.getLogger(__name__)
+
+
+@backup_ns.route('/export')
+class Export(Resource):
+
+    @auth
+    def post(self):
+        """
+        Export by query
+        """
+        data = request.get_json()
+        query = data["query"]
+        try:
+            file_name = f"leek-{datetime.now().strftime('%b-%d-%YT%H-%M-%S').lower()}.json"
+            docs = export_by_query(g.index_alias, query)
+            content = {
+                "index": g.index_alias,
+                "query": query,
+                "count": len(docs),
+                "result": docs
+            }
+            with tempfile.NamedTemporaryFile(suffix='.json') as tmp:
+                with open(tmp.name, "w") as file_object:
+                    json.dump(content, file_object, indent=2)
+                return send_file(
+                    str(tmp.name),
+                    download_name=file_name,
+                    as_attachment=True,
+                    mimetype="application/json"
+                )
+        except es_exceptions.ConnectionError:
+            return responses.search_backend_unavailable
+        except es_exceptions.NotFoundError:
+            return responses.application_not_found

--- a/app/leek/requirements.txt
+++ b/app/leek/requirements.txt
@@ -14,6 +14,7 @@ cachecontrol[filecache]==0.12.6
 printy==2.1.1
 supervisor==4.2.1
 ciso8601==2.1.3
+werkzeug==2.1.2
 
 # Additional for agent
 kombu==5.2.4

--- a/app/web/src/api/backup.tsx
+++ b/app/web/src/api/backup.tsx
@@ -1,0 +1,35 @@
+import { request } from "./request";
+import { getFilterQuery, TaskFilters } from "./task";
+
+export interface Backup {
+  exportByQuery(
+    app_name: string,
+    app_env: string,
+    filters: TaskFilters,
+    dry_run: boolean
+  ): any;
+}
+
+export class BackupService implements Backup {
+  exportByQuery(
+    app_name: string,
+    app_env: string,
+    filters: TaskFilters,
+  ) {
+    return request({
+      method: "POST",
+      path: `/v1/backup/export`,
+      headers: {
+        "x-leek-app-name": app_name,
+        "x-leek-app-env": app_env,
+      },
+      body: {
+        query: {
+          bool: {
+            must: getFilterQuery(app_env, filters),
+          },
+        },
+      },
+    });
+  }
+}

--- a/app/web/src/utils/errors.tsx
+++ b/app/web/src/utils/errors.tsx
@@ -16,6 +16,7 @@ export function handleAPIResponse(response) {
 }
 
 export function handleAPIError(error) {
+  console.log(error);
   if (error && error.message) {
     // Network error (API DOWN / OFFLINE)
     if (error.name == "TypeError") {


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Not possible to export filtered tasks

### What is the new behavior (if this is a feature change)?

Users can now click on `Export Filtered` button and Leek backend will prepare the tasks as json and sends them to Leek frontend, the later will create a blob and an anchor link on DOM tree and click on the link programmatically to download the json file.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
