### PR TITLE
Ignore empty agent payloads

### DIFF
--- a/app/leek/api/routes/events.py
+++ b/app/leek/api/routes/events.py
@@ -27,7 +27,8 @@ class ProcessEvents(Resource):
         """
         payload = request.get_json()
         if not len(payload):
-            return "Empty payload, nothing to be processed", 400
+            logger.warning("Empty payload, nothing to be processed!")
+            return {"success": 0}, 201
         result, status = merge_events(g.context["index_alias"], payload)
         return result, status
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

### What is the current behavior? (You can also link to an open issue here)

Returns validation error to the agent when the payload is empty which causes the tasks events processing to be blocked

### What is the new behavior (if this is a feature change)?

Log a warning that the api received an empty payload from the agent and return 201 to the agent.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
