### PR TITLE
Broker queues statistics

### DIFF
--- a/app/leek/api/blueprints.py
+++ b/app/leek/api/blueprints.py
@@ -7,6 +7,7 @@ from leek.api.routes.search import search_bp
 from leek.api.routes.agent import agent_bp
 from leek.api.routes.control import control_bp
 from leek.api.routes.backup import backup_bp
+from leek.api.routes.broker import broker_bp
 
 
 def register_blueprints(app):
@@ -20,3 +21,4 @@ def register_blueprints(app):
     app.register_blueprint(agent_bp)
     app.register_blueprint(control_bp)
     app.register_blueprint(backup_bp)
+    app.register_blueprint(broker_bp)

--- a/app/leek/api/errors/responses.py
+++ b/app/leek/api/errors/responses.py
@@ -54,6 +54,15 @@ task_retry_subscription_not_found = {
                                         }
                                     }, 404
 
+
+subscription_not_found = {
+                             "error": {
+                                 "code": "404003",
+                                 "message": "Failed to lookup broker subscription",
+                                 "reason": "Subscription not found, subscription names should be in the form of `app_name-env_name`"
+                             }
+                         }, 404
+
 wrong_application_app_key = {
                                 "error": {
                                     "code": "401001",

--- a/app/leek/api/routes/broker.py
+++ b/app/leek/api/routes/broker.py
@@ -1,0 +1,35 @@
+import logging
+
+from flask import Blueprint, g
+from flask_restx import Resource
+
+from leek.api.control.stats import get_fanout_queue_drift, get_subscription_queues
+from leek.api.decorators import auth
+from leek.api.routes.api_v1 import api_v1
+
+broker_bp = Blueprint('broker', __name__, url_prefix='/v1/broker')
+broker_ns = api_v1.namespace('broker', 'Broker operations.')
+
+logger = logging.getLogger(__name__)
+
+
+@broker_ns.route('/drift')
+class Drift(Resource):
+
+    @auth
+    def get(self):
+        """
+        Get search drift
+        """
+        return get_fanout_queue_drift(g.index_alias, g.app_name, g.app_env)
+
+
+@broker_ns.route('/queues')
+class Queues(Resource):
+
+    @auth
+    def get(self):
+        """
+        List subscription queues
+        """
+        return get_subscription_queues(g.app_name, g.app_env)

--- a/app/leek/api/routes/search.py
+++ b/app/leek/api/routes/search.py
@@ -3,7 +3,6 @@ import logging
 from flask import Blueprint, request, g
 from flask_restx import Resource
 
-from leek.api.control.stats import get_fanout_queue_drift
 from leek.api.decorators import auth
 from leek.api.schemas.search_params import SearchParamsSchema
 from leek.api.db.search import search_index
@@ -27,17 +26,6 @@ class Search(Resource):
         query = request.get_json()
         params = SearchParamsSchema.validate(request.args.to_dict())
         return search_index(g.index_alias, query, params)
-
-
-@search_ns.route('/drift')
-class Drift(Resource):
-
-    @auth
-    def get(self):
-        """
-        Get search drift
-        """
-        return get_fanout_queue_drift(g.index_alias, g.app_name, g.app_env)
 
 
 @search_ns.route('/workflow')

--- a/app/leek/requirements.txt
+++ b/app/leek/requirements.txt
@@ -19,3 +19,4 @@ werkzeug==2.1.2
 # Additional for agent
 kombu==5.2.4
 redis==4.1.4
+pyrabbit==1.1.0

--- a/app/web/src/api/broker.tsx
+++ b/app/web/src/api/broker.tsx
@@ -1,0 +1,31 @@
+import {request} from "./request";
+
+export interface Broker {
+    getBrokerDrift(app_name: string, app_env: string): any;
+
+    getBrokerQueues(app_name: string, app_env: string): any;
+}
+
+export class BrokerService implements Broker {
+    getBrokerDrift(app_name: string, app_env: string) {
+        return request({
+            method: "GET",
+            path: `/v1/broker/drift`,
+            headers: {
+                "x-leek-app-name": app_name,
+                "x-leek-app-env": app_env,
+            },
+        });
+    }
+
+    getBrokerQueues(app_name: string, app_env: string) {
+        return request({
+            method: "GET",
+            path: `/v1/broker/queues`,
+            headers: {
+                "x-leek-app-name": app_name,
+                "x-leek-app-env": app_env,
+            },
+        });
+    }
+}

--- a/app/web/src/api/metrics.tsx
+++ b/app/web/src/api/metrics.tsx
@@ -1,12 +1,9 @@
 import { getTimeFilterQuery, search, TimeFilters } from "./search";
-import { request } from "./request";
 
 export interface Metrics {
   getBasicMetrics(app_name: string, app_env: string, filters: TimeFilters): any;
 
   getMetadata(app_name: string): any;
-
-  getSearchDrift(app_name: string, app_env: string): any;
 }
 
 export class MetricsService implements Metrics {
@@ -123,16 +120,5 @@ export class MetricsService implements Metrics {
         from_: 0,
       }
     );
-  }
-
-  getSearchDrift(app_name: string, app_env: string) {
-    return request({
-      method: "GET",
-      path: `/v1/search/drift`,
-      headers: {
-        "x-leek-app-name": app_name,
-        "x-leek-app-env": app_env,
-      },
-    });
   }
 }

--- a/app/web/src/components/data/BrokerQueueData.tsx
+++ b/app/web/src/components/data/BrokerQueueData.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Typography, Tag } from "antd";
+import {formatBytes, formatNumber} from "../../utils/size";
+
+const Text = Typography.Text;
+
+function BrokerQueueData() {
+  return [
+    {
+      title: "Overview",
+      children: [
+        {
+          title: "Queue",
+          dataIndex: "name",
+          key: "name",
+          render: (name) => {
+            return (
+                <Text strong style={{ color: "rgb(52, 156, 80)" }}>
+                  {name}
+                </Text>
+            );
+          },
+        },
+        {
+          title: "State",
+          dataIndex: "state",
+          key: "state",
+          render: (state) => {
+            return state === "running" ? <Tag color="green">{state}</Tag> : <Tag color="gray">{state}</Tag>;
+          },
+        },
+        {
+          title: "Memory",
+          dataIndex: "memory",
+          key: "memory",
+          render: (memory) => {
+            return <Tag color="cyan">{formatBytes(memory, 0)}</Tag>;
+          },
+        },
+        {
+          title: "Consumers",
+          dataIndex: "consumers",
+          key: "consumers",
+          render: (consumers) => {
+            return <Tag color="cyan">{consumers}</Tag>;
+          },
+        },
+      ]
+    },
+    {
+      title: "Messages",
+      children: [
+        {
+          title: "Ready",
+          dataIndex: "messages",
+          key: "ready",
+          render: (messages) => {
+            return <Tag color="green">{formatNumber(messages.ready, 0)}</Tag>;
+          },
+        },
+        {
+          title: "Unacked",
+          dataIndex: "messages",
+          key: "unacked",
+          render: (messages) => {
+            return <Tag color="purple">{formatNumber(messages.unacknowledged, 0)}</Tag>;
+          },
+        },
+        {
+          title: "Total",
+          dataIndex: "messages",
+          key: "total",
+          render: (messages) => {
+            return <Tag color="blue">{formatNumber(messages.total, 0)}</Tag>;
+          },
+        },
+      ]
+    },
+    {
+      title: "Rates",
+      children: [
+        {
+          title: "Incoming",
+          dataIndex: "rates",
+          key: "incoming",
+          render: (rates) => {
+            return <Tag color="red">{rates.incoming}/s</Tag>;
+          },
+        },
+        {
+          title: "Deliver/Get",
+          dataIndex: "rates",
+          key: "deliver_get",
+          render: (rates) => {
+            return <Tag color="yellow">{rates.deliver_get}/s</Tag>;
+          },
+        },
+        {
+          title: "Ack",
+          dataIndex: "rates",
+          key: "ack",
+          render: (rates) => {
+            return <Tag color="green">{rates.ack}/s</Tag>;
+          },
+        },
+      ]
+    }
+  ];
+}
+
+export default BrokerQueueData;

--- a/app/web/src/components/data/IndexQueueData.tsx
+++ b/app/web/src/components/data/IndexQueueData.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Typography, Tag } from "antd";
+import {formatNumber} from "../../utils/size";
 
 const Text = Typography.Text;
 
-function QueueData() {
+function IndexQueueData() {
   return [
     {
       title: "Queue",
@@ -22,7 +23,7 @@ function QueueData() {
       dataIndex: "doc_count",
       key: "doc_count",
       render: (doc_count) => {
-        return <Tag>{doc_count}</Tag>;
+        return <Tag>{formatNumber(doc_count, 0)}</Tag>;
       },
     },
     {
@@ -30,7 +31,7 @@ function QueueData() {
       dataIndex: "QUEUED",
       key: "QUEUED",
       render: (QUEUED) => {
-        return <Tag color="blue">{QUEUED}</Tag>;
+        return <Tag color="blue">{formatNumber(QUEUED, 0)}</Tag>;
       },
     },
     {
@@ -38,7 +39,7 @@ function QueueData() {
       dataIndex: "RECEIVED",
       key: "RECEIVED",
       render: (RECEIVED) => {
-        return <Tag color="blue">{RECEIVED}</Tag>;
+        return <Tag color="blue">{formatNumber(RECEIVED, 0)}</Tag>;
       },
     },
     {
@@ -46,7 +47,7 @@ function QueueData() {
       dataIndex: "STARTED",
       key: "STARTED",
       render: (STARTED) => {
-        return <Tag color="blue">{STARTED}</Tag>;
+        return <Tag color="blue">{formatNumber(STARTED, 0)}</Tag>;
       },
     },
     {
@@ -54,7 +55,7 @@ function QueueData() {
       dataIndex: "SUCCEEDED",
       key: "SUCCEEDED",
       render: (SUCCEEDED) => {
-        return <Tag color="green">{SUCCEEDED}</Tag>;
+        return <Tag color="green">{formatNumber(SUCCEEDED, 0)}</Tag>;
       },
     },
     {
@@ -62,7 +63,7 @@ function QueueData() {
       dataIndex: "RECOVERED",
       key: "RECOVERED",
       render: (RECOVERED) => {
-        return <Tag color="green">{RECOVERED}</Tag>;
+        return <Tag color="green">{formatNumber(RECOVERED, 0)}</Tag>;
       },
     },
     {
@@ -70,7 +71,7 @@ function QueueData() {
       dataIndex: "RETRY",
       key: "RETRY",
       render: (RETRY) => {
-        return <Tag color="orange">{RETRY}</Tag>;
+        return <Tag color="orange">{formatNumber(RETRY, 0)}</Tag>;
       },
     },
     {
@@ -78,7 +79,7 @@ function QueueData() {
       dataIndex: "FAILED",
       key: "FAILED",
       render: (FAILED) => {
-        return <Tag color="red">{FAILED}</Tag>;
+        return <Tag color="red">{formatNumber(FAILED, 0)}</Tag>;
       },
     },
     {
@@ -86,7 +87,7 @@ function QueueData() {
       dataIndex: "CRITICAL",
       key: "CRITICAL",
       render: (CRITICAL) => {
-        return <Tag color="red">{CRITICAL}</Tag>;
+        return <Tag color="red">{formatNumber(CRITICAL, 0)}</Tag>;
       },
     },
     {
@@ -94,10 +95,10 @@ function QueueData() {
       dataIndex: "REVOKED",
       key: "REVOKED",
       render: (REVOKED) => {
-        return <Tag color="purple">{REVOKED}</Tag>;
+        return <Tag color="purple">{formatNumber(REVOKED, 0)}</Tag>;
       },
     },
   ];
 }
 
-export default QueueData;
+export default IndexQueueData;

--- a/app/web/src/utils/size.tsx
+++ b/app/web/src/utils/size.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Tooltip } from "antd";
+
+
+export function formatBytes(bytes, decimals = 2) {
+    if (!+bytes) return '0 Bytes'
+
+    const k = 1024
+    const dm = decimals < 0 ? 0 : decimals
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+    const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+    return <Tooltip title={bytes}>{`${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`}</Tooltip>
+}
+
+export function formatNumber(number, decimals = 2) {
+    if (!+number) return '0'
+
+    const k = 1000
+    const dm = decimals < 0 ? 0 : decimals
+    const sizes = ['', 'K', 'M', 'B', 'T']
+
+    const i = Math.floor(Math.log(number) / Math.log(k))
+
+    return <Tooltip title={number}>{`${parseFloat((number / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`}</Tooltip>
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Leek only list the queues aggregated from the indexed tasks which can be delayed from the actual queues depths.

### What is the new behavior (if this is a feature change)?

In addition to showing the list of queues from index, retrieve the realtime statistics of queues from the broker and render them in a table. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

Queue specific operations (purging queue, deleting queue, ....) can be added in the future.
