### PR TITLE
Add external link to datadog apm traces

### DIFF
--- a/app/web/src/containers/tasks/TaskDetails.tsx
+++ b/app/web/src/containers/tasks/TaskDetails.tsx
@@ -36,7 +36,8 @@ import {
   PlayCircleOutlined,
   FieldTimeOutlined,
   CheckOutlined,
-  CloseOutlined
+  CloseOutlined,
+  FundFilled
 } from "@ant-design/icons";
 import {LeekPie} from "../../components/charts/Pie";
 import {useThemeSwitcher} from "react-css-theme-switcher";
@@ -187,6 +188,11 @@ export default (props) => {
         .finally(() => setBuildingTree(false));
   }
 
+
+  function twoWeeksFromNow() {
+    return Date.now() - 14 * 24 * 60 * 60 * 1000;
+  }
+
   return (
     <TaskDetails>
       <Modal
@@ -301,6 +307,14 @@ export default (props) => {
             <Text copyable={{ text: window.location.href }} strong>
               LINK
             </Text>
+            <a
+                href={`https://app.datadoghq.com/apm/traces?query=%40celery.correlation_id%3A${props.task.uuid}%20&start=${twoWeeksFromNow()}&end=${Date.now()}&paused=false`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{color: "orchid"}}
+            >
+              Datadog <FundFilled />
+            </a>
           </Space>
         </Col>
       </Row>


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Users have to manually copy/past task id from Leek to datadog apm search filter.

### What is the new behavior (if this is a feature change)?

Users will now be able to just click an anchor link that will open the datadog apm traces in a new tab.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
