### PR TITLE
Auto refresh tasks/queues

### DIFF
--- a/app/web/src/pages/tasks.tsx
+++ b/app/web/src/pages/tasks.tsx
@@ -19,7 +19,7 @@ import {
   CaretUpOutlined,
   CaretDownOutlined,
   CheckCircleOutlined,
-  ExclamationCircleOutlined,
+  ExclamationCircleOutlined, PauseOutlined, CaretRightOutlined, LoadingOutlined,
 } from "@ant-design/icons";
 
 import TaskDataColumns from "../components/data/TaskData";
@@ -44,6 +44,8 @@ const TerminalStates = [
 const { confirm } = Modal;
 const { Text } = Typography;
 
+let timeout;
+
 const TasksPage: React.FC = () => {
   // STATE
   const service = new TaskService();
@@ -59,6 +61,7 @@ const TasksPage: React.FC = () => {
     offset: 900000,
   });
   const [order, setOrder] = useState<string>("desc");
+  const [live, setLive] = useState<boolean>(false);
 
   // Data
   const columns = TaskDataColumns();
@@ -101,12 +104,19 @@ const TasksPage: React.FC = () => {
 
   // Hooks
   useEffect(() => {
-    refresh(pagination);
-  }, [currentApp, currentEnv, filters, timeFilters, order]);
+    // Stop refreshing queues
+    if (timeout) clearInterval(timeout);
 
-  useEffect(() => {
-    //console.log(tasks)
-  }, [tasks]);
+    if (live) {
+      refresh(pagination);
+      timeout = setInterval(() => {
+        refresh(pagination);
+      }, 7000);
+    }
+    else {
+      refresh(pagination);
+    }
+  }, [currentApp, currentEnv, filters, timeFilters, order, live]);
 
   // UI Callbacks
   function refresh(pager = { current: 1, pageSize: 20 }) {
@@ -280,6 +290,15 @@ const TasksPage: React.FC = () => {
         .finally(() => setTasksExporting(false));
   }
 
+  useEffect(() => {
+    // Stop refreshing queues
+    if (timeout) clearInterval(timeout);
+
+    return () => {
+      clearInterval(timeout);
+    };
+  }, []);
+
   return (
     <>
       <Helmet>
@@ -349,9 +368,17 @@ const TasksPage: React.FC = () => {
                         </Button>
                       }
                       <Button
+                          size="small"
+                          onClick={() => {setLive(!live)}}
+                          icon={live ? <PauseOutlined style={{color: '#fff'}} /> : <CaretRightOutlined style={{color: "#33ccb8"}}/>}
+                          type={live ? "primary" : "secondary"}
+                          danger={live}
+                      />
+                      <Button
                         size="small"
                         onClick={handleRefresh}
-                        icon={<SyncOutlined />}
+                        icon={live ? <LoadingOutlined /> : <SyncOutlined />}
+                        disabled={live}
                       />
                     </Space>
                   </Col>


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature https://github.com/kodless/leek/issues/3

### What is the current behavior? (You can also link to an open issue here)

When users look at tasks they see how time is ticking near each task, but new tasks are not appearing — which makes them nervous and forces to constantly click refresh button.

* **What is the new behavior (if this is a feature change)?**

re-fresh the data on tasks/queues pages periodically.

- every 5 seconds for queues
- every 7 seconds for tasks

If `LEEK_ES_DEFAULT_REFRESH_INTERVAL` is greater than 5/7 eg. 20 seconds, the data will be auto refreshed every 20 seconds even if refresh requests are sent every 5/7 seconds.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
