### PR TITLE
Sort queues

### DIFF
--- a/app/leek/api/control/stats.py
+++ b/app/leek/api/control/stats.py
@@ -141,13 +141,13 @@ def get_subscription_queues(app_name, app_env, hide_pid_boxes=True):
         queue = {
             "name": q["name"],
             "state": q.get("state", "unknown"),
-            "memory": q["memory"],
-            "consumers": q["consumers"],
+            "memory": q.get("memory", 0),
+            "consumers": q.get("consumers", 0),
             "durable": q["durable"],
             "messages": {
-                "ready": q["messages_ready"],
-                "unacknowledged": q["messages_unacknowledged"],
-                "total": q["messages"]
+                "ready": q.get("messages_ready", 0),
+                "unacknowledged": q.get("messages_unacknowledged", 0),
+                "total": q.get("messages", 0)
             },
         }
         if "message_stats" in q:

--- a/app/web/src/components/data/BrokerQueueData.tsx
+++ b/app/web/src/components/data/BrokerQueueData.tsx
@@ -36,6 +36,9 @@ function BrokerQueueData(data) {
           render: (state) => {
             return state === "running" ? <Tag color="green">{state}</Tag> : <Tag color="gray">{state}</Tag>;
           },
+          filters: filterData(data)(i => i.state),
+          filterSearch: true,
+          onFilter: (value: string, record) => record.state && record.state.includes(value),
         },
         {
           title: "Memory",
@@ -44,6 +47,7 @@ function BrokerQueueData(data) {
           render: (memory) => {
             return <Tag color="cyan">{formatBytes(memory, 0)}</Tag>;
           },
+          sorter: (a, b) => a.memory - b.memory,
         },
         {
           title: "Consumers",
@@ -52,6 +56,7 @@ function BrokerQueueData(data) {
           render: (consumers) => {
             return <Tag color="cyan">{consumers}</Tag>;
           },
+          sorter: (a, b) => a.consumers - b.consumers,
         },
       ]
     },
@@ -65,6 +70,7 @@ function BrokerQueueData(data) {
           render: (messages) => {
             return <Tag color="green">{formatNumber(messages.ready, 0)}</Tag>;
           },
+          sorter: (a, b) => a.messages.ready - b.messages.ready,
         },
         {
           title: "Unacked",
@@ -73,6 +79,7 @@ function BrokerQueueData(data) {
           render: (messages) => {
             return <Tag color="purple">{formatNumber(messages.unacknowledged, 0)}</Tag>;
           },
+          sorter: (a, b) => a.messages.unacknowledged - b.messages.unacknowledged,
         },
         {
           title: "Total",
@@ -81,6 +88,8 @@ function BrokerQueueData(data) {
           render: (messages) => {
             return <Tag color="blue">{formatNumber(messages.total, 0)}</Tag>;
           },
+          defaultSortOrder: "descend",
+          sorter: (a, b) => a.messages.total - b.messages.total,
         },
       ]
     },
@@ -94,6 +103,7 @@ function BrokerQueueData(data) {
           render: (rates) => {
             return rates.incoming === null ? "-" : <Tag color="red">{rates.incoming}/s</Tag>;
           },
+          sorter: (a, b) => a.rates.incoming - b.rates.incoming,
         },
         {
           title: "Deliver/Get",
@@ -102,6 +112,7 @@ function BrokerQueueData(data) {
           render: (rates) => {
             return rates.deliver_get === null ? "-" : <Tag color="yellow">{rates.deliver_get}/s</Tag>;
           },
+          sorter: (a, b) => a.rates.deliver_get - b.rates.deliver_get,
         },
         {
           title: "Ack",
@@ -110,6 +121,7 @@ function BrokerQueueData(data) {
           render: (rates) => {
             return rates.ack === null ? "-" : <Tag color="green">{rates.ack}/s</Tag>;
           },
+          sorter: (a, b) => a.rates.ack - b.rates.ack,
         },
       ]
     }

--- a/app/web/src/components/data/IndexQueueData.tsx
+++ b/app/web/src/components/data/IndexQueueData.tsx
@@ -33,6 +33,8 @@ function IndexQueueData(data) {
       render: (doc_count) => {
         return <Tag>{formatNumber(doc_count, 0)}</Tag>;
       },
+      defaultSortOrder: "descend",
+      sorter: (a, b) => a.doc_count - b.doc_count,
     },
     {
       title: "Queued",
@@ -41,6 +43,7 @@ function IndexQueueData(data) {
       render: (QUEUED) => {
         return <Tag color="blue">{formatNumber(QUEUED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.QUEUED - b.QUEUED,
     },
     {
       title: "Received",
@@ -49,6 +52,7 @@ function IndexQueueData(data) {
       render: (RECEIVED) => {
         return <Tag color="blue">{formatNumber(RECEIVED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.RECEIVED - b.RECEIVED,
     },
     {
       title: "Started",
@@ -57,6 +61,7 @@ function IndexQueueData(data) {
       render: (STARTED) => {
         return <Tag color="blue">{formatNumber(STARTED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.STARTED - b.STARTED,
     },
     {
       title: "Succeeded",
@@ -65,6 +70,7 @@ function IndexQueueData(data) {
       render: (SUCCEEDED) => {
         return <Tag color="green">{formatNumber(SUCCEEDED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.SUCCEEDED - b.SUCCEEDED,
     },
     {
       title: "Recovered",
@@ -73,6 +79,7 @@ function IndexQueueData(data) {
       render: (RECOVERED) => {
         return <Tag color="green">{formatNumber(RECOVERED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.RECOVERED - b.RECOVERED,
     },
     {
       title: "Retry",
@@ -81,6 +88,7 @@ function IndexQueueData(data) {
       render: (RETRY) => {
         return <Tag color="orange">{formatNumber(RETRY, 0)}</Tag>;
       },
+      sorter: (a, b) => a.RETRY - b.RETRY,
     },
     {
       title: "Failed",
@@ -89,6 +97,7 @@ function IndexQueueData(data) {
       render: (FAILED) => {
         return <Tag color="red">{formatNumber(FAILED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.FAILED - b.FAILED,
     },
     {
       title: "Critical",
@@ -97,6 +106,7 @@ function IndexQueueData(data) {
       render: (CRITICAL) => {
         return <Tag color="red">{formatNumber(CRITICAL, 0)}</Tag>;
       },
+      sorter: (a, b) => a.CRITICAL - b.CRITICAL,
     },
     {
       title: "Revoked",
@@ -105,6 +115,7 @@ function IndexQueueData(data) {
       render: (REVOKED) => {
         return <Tag color="purple">{formatNumber(REVOKED, 0)}</Tag>;
       },
+      sorter: (a, b) => a.REVOKED - b.REVOKED,
     },
   ];
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

No way to sort queues

### What is the new behavior (if this is a feature change)?

Sort indexed/broker queues by any queue metric, this will be useful for sorting queues by:
- Big memory usage
- Large amount of queued tasks
- Low ack rate
- High publish rate
- etc...

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No