### PR TITLE
Add support for application admins

### DIFF
--- a/app/leek/api/db/store.py
+++ b/app/leek/api/db/store.py
@@ -161,10 +161,17 @@ class FanoutTrigger:
 
 
 @dataclass()
+class ApplicationAdmin:
+    email: str
+    since: str
+
+
+@dataclass()
 class Application:
     app_name: str
     app_key: str
     app_description: str
     created_at: str
     owner: str
+    admins: Optional[List[ApplicationAdmin]]
     fo_triggers: List[FanoutTrigger] = field(default_factory=lambda: [])

--- a/app/leek/api/errors/responses.py
+++ b/app/leek/api/errors/responses.py
@@ -119,6 +119,21 @@ task_not_routable = {
                         }
                     }, 400
 
+leek_auth_disabled = {
+                         "error": {
+                             "code": "400007",
+                             "message": "Leek auth is disabled",
+                             "reason": "Please enable first using LEEK_API_ENABLE_AUTH"
+                         }
+                     }, 400
+ineligible_admin = {
+                        "error": {
+                            "code": "400008",
+                            "message": "Ineligible admin",
+                            "reason": "User email is not part of LEEK_API_WHITELISTED_ORGS"
+                        }
+                    }, 400
+
 wrong_access_refused = {
                            "error": {
                                "code": "401004",

--- a/app/leek/api/routes/agent.py
+++ b/app/leek/api/routes/agent.py
@@ -55,7 +55,10 @@ class AgentControl(Resource):
         """
         return self.get_agent_info()
 
-    @auth(allowed_org_names=[settings.LEEK_API_OWNER_ORG])
+    @auth(
+        allowed_org_names=[settings.LEEK_API_OWNER_ORG],
+        only_app_admins=True
+    )
     def post(self):
         """
         Start/Restart agent

--- a/app/leek/api/routes/broker.py
+++ b/app/leek/api/routes/broker.py
@@ -43,7 +43,7 @@ class Queues(Resource):
 @broker_ns.route('/queue/<string:queue_name>/purge')
 class PurgeQueue(Resource):
 
-    @auth(only_app_owner=True)
+    @auth(only_app_admins=True)
     def delete(self, queue_name):
         """
         Purge a specific queue

--- a/app/web/src/api/application.tsx
+++ b/app/web/src/api/application.tsx
@@ -27,6 +27,11 @@ export interface Application {
   ): any;
 
   deleteFanoutTrigger(app_name: string, trigger_id: string): any;
+
+
+  grantApplicationAdmin(app_name: string, admin_email: string): any;
+
+  revokeApplicationAdmin(app_name: string, admin_email: string): any;
 }
 
 export class ApplicationService implements Application {
@@ -126,6 +131,26 @@ export class ApplicationService implements Application {
     return request({
       method: "GET",
       path: `/v1/applications/tasks/cleanup`,
+      headers: {
+        "x-leek-app-name": app_name,
+      },
+    });
+  }
+
+  grantApplicationAdmin(app_name, admin_email) {
+    return request({
+      method: "POST",
+      path: `/v1/applications/admins/${admin_email}`,
+      headers: {
+        "x-leek-app-name": app_name,
+      },
+    });
+  }
+
+  revokeApplicationAdmin(app_name, admin_email) {
+    return request({
+      method: "DELETE",
+      path: `/v1/applications/admins/${admin_email}`,
       headers: {
         "x-leek-app-name": app_name,
       },

--- a/app/web/src/components/data/AdminData.tsx
+++ b/app/web/src/components/data/AdminData.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import TimeAgo from "react-timeago";
+
+import { Typography, Space, Button } from "antd";
+import { DeleteOutlined } from "@ant-design/icons";
+import moment from "moment";
+
+const Text = Typography.Text;
+
+function AdminData(props) {
+  return [
+    {
+      title: "Email",
+      dataIndex: "email",
+      key: "email",
+      render: (email) => {
+        return <Text strong style={{ color: "gold" }}>
+          {email}
+        </Text>;
+      },
+    },
+    {
+      title: "Since",
+      dataIndex: "since",
+      key: "since",
+      render: (since) => {
+        return <Text style={{ color: "rgba(45,137,183,0.8)" }} strong>
+          {since ? moment(since).format("MMM D HH:mm:ss Z") : "-"} -{" "}
+          <Text>{since ? <TimeAgo date={since} /> : "-"}</Text>
+        </Text>
+      },
+    },
+    {
+      title: "Actions",
+      dataIndex: "email",
+      key: "email",
+      render: (email) => {
+        return (
+          <Space direction="horizontal" style={{ float: "right" }}>
+            <Button
+              onClick={() => props.handleDeleteAdmin(email)}
+              size="small"
+              type="primary"
+              ghost
+              danger
+              loading={props.adminsModifying}
+              icon={<DeleteOutlined />}
+            />
+          </Space>
+        );
+      },
+    },
+  ];
+}
+
+export default AdminData;

--- a/app/web/src/containers/apps/Admins.tsx
+++ b/app/web/src/containers/apps/Admins.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useState } from "react";
+import { Row, Button, Col, Card, Typography, Table, Modal, Form, Input, Empty, Space} from "antd";
+import { AppstoreAddOutlined, DeploymentUnitOutlined, BellOutlined} from "@ant-design/icons";
+
+import AdminDataColumns from "../../components/data/AdminData";
+
+import { ApplicationService } from "../../api/application";
+import { handleAPIError, handleAPIResponse } from "../../utils/errors";
+import { useApplication } from "../../context/ApplicationProvider";
+
+const Text = Typography.Text;
+const FormItem = Form.Item;
+
+
+const Admins = (props) => {
+  const [form] = Form.useForm();
+  const service = new ApplicationService();
+  const { updateApplication } = useApplication();
+
+  const [createAdminModalVisible, setCreateAdminModalVisible] =
+    useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {}, []);
+
+  function doAddAdmin(admin) {
+    setLoading(true);
+    service
+      .grantApplicationAdmin(props.selectedApp.app_name, admin.email)
+      .then(handleAPIResponse)
+      .then((application: any) => {
+        updateApplication(application);
+        props.setSelectedApp(application);
+        reset();
+      }, handleAPIError)
+      .catch(handleAPIError)
+      .finally(() => {
+        setLoading(false);
+      });
+  }
+
+  function doDeleteAdmin(admin_email) {
+    setLoading(true);
+    service
+      .revokeApplicationAdmin(props.selectedApp.app_name, admin_email)
+      .then(handleAPIResponse)
+      .then((application: any) => {
+        updateApplication(application);
+        props.setSelectedApp(application);
+      }, handleAPIError)
+      .catch(handleAPIError)
+      .finally(() => {
+        setLoading(false);
+      });
+  }
+
+
+  function reset() {
+    setCreateAdminModalVisible(false);
+    form.resetFields();
+  }
+
+  const formItems = (
+    <>
+      <FormItem
+        name="email"
+        rules={[
+          { required: true, message: "Please input the admin email!" },
+          {
+            type: "email",
+            message: "This field must be a valid email.",
+          },
+        ]}
+      >
+        <Input
+          prefix={<DeploymentUnitOutlined style={{ fontSize: 13 }} />}
+          placeholder="Admin email"
+        />
+      </FormItem>
+    </>
+  );
+
+  return (
+    <Row style={{ width: "100%", marginBottom: "16px" }}>
+      {/*Create Admin*/}
+      <Modal
+        title={
+          <Space>
+            <BellOutlined />
+            Create Admin
+          </Space>
+        }
+        visible={createAdminModalVisible}
+        onCancel={reset}
+        footer={[
+          <Button key="cancel" size="small" onClick={reset}>
+            Cancel
+          </Button>,
+          <Button
+            form="createAdmin"
+            key="submit"
+            htmlType="submit"
+            size="small"
+            type="primary"
+            loading={loading}
+          >
+            Create
+          </Button>,
+        ]}
+      >
+        <Form
+          onFinish={doAddAdmin}
+          form={form}
+          id="createAdmin"
+          initialValues={{ }}
+        >
+          {formItems}
+        </Form>
+      </Modal>
+
+      <Card
+        size="small"
+        style={{ width: "100%" }}
+        bodyStyle={{ paddingBottom: 0, paddingRight: 0, paddingLeft: 0 }}
+        title={
+          <Row justify="space-between">
+            <Col>
+              <Space>
+                <BellOutlined />
+                <Text strong>Application admins</Text>
+              </Space>
+            </Col>
+            <Col>
+              <Button
+                onClick={() => setCreateAdminModalVisible(true)}
+                size="small"
+                type="primary"
+                ghost
+                icon={<AppstoreAddOutlined />}
+              />
+            </Col>
+          </Row>
+        }
+      >
+        <Table
+          dataSource={props.selectedApp.admins}
+          columns={AdminDataColumns({
+            handleDeleteAdmin: doDeleteAdmin,
+            adminsModifying: loading,
+          })}
+          showHeader={false}
+          pagination={false}
+          size="small"
+          rowKey="id"
+          style={{ width: "100%" }}
+          scroll={{ x: "100%" }}
+          locale={{
+            emptyText: (
+              <div style={{ textAlign: "center" }}>
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={
+                    <span>
+                      No <a href="#API">admins</a> found
+                    </span>
+                  }
+                />
+              </div>
+            ),
+          }}
+        />
+      </Card>
+    </Row>
+  );
+};
+
+export default Admins;

--- a/app/web/src/containers/apps/Applications.tsx
+++ b/app/web/src/containers/apps/Applications.tsx
@@ -20,6 +20,7 @@ import { ExclamationCircleOutlined, AppstoreOutlined } from "@ant-design/icons";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { atelierCaveDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
+import Admins from "./Admins";
 import Triggers from "./Triggers";
 import AppsList from "./AppsList";
 
@@ -341,6 +342,11 @@ const Applications = () => {
                   </>
                 )}
               </Card>
+
+              <Admins
+                  selectedApp={selectedApp}
+                  setSelectedApp={setSelectedApp}
+              />
 
               <Triggers
                 selectedApp={selectedApp}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

No way to give specific users access to call dangerous administrative operations like purging queues, stopping/starting agents.

### What is the new behavior (if this is a feature change)?

Adds support for:
- Granting application admin permission to specific Leek users (by email)
  - only if email domain is member of LEEK_API_WHITELISTED_ORGS for enterprise emails.
  - only if email user is member of LEEK_API_WHITELISTED_ORGS for gmail emails
- Revoking application admin permission from existing admin
- Listing existing Leek application admins

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
