### PR TITLE
Fix broker queues API with Redis.

### DIFF
--- a/app/leek/api/control/stats.py
+++ b/app/leek/api/control/stats.py
@@ -122,7 +122,8 @@ def get_subscription_queues(app_name, app_env, hide_pid_boxes=True):
     # noinspection PyBroadException
     try:
         connection, client = get_manager_client(subscription)
-        client.is_alive()
+        if connection.transport.driver_type == "amqp":
+            client.is_alive()
     except NetworkError:
         return responses.wrong_access_refused
     except Exception:
@@ -181,7 +182,8 @@ def purge_queue(app_name, app_env, queue_name):
     # noinspection PyBroadException
     try:
         connection, client = get_manager_client(subscription)
-        client.is_alive()
+        if connection.transport.driver_type == "amqp":
+            client.is_alive()
     except NetworkError:
         return responses.wrong_access_refused
     except Exception:


### PR DESCRIPTION
With non-AMPQ brokers `get_manager_client` returns `None` for the client which obviously doesn't have the `is_alive()` method. So we need to check if the connection driver type is AMQP otherwise `/v1/broker/queues` returns 503 with a `broker_not_reachable` error. Fix the same issue with `purge_queue()` which I haven't encountered.

I'm not sure where are the tests, but adding a call to `/v1/broker/queues` with a Redis subscription configured would have caught it. I don't think that there's any need to update the documentation. I can open an issue if it's needed. There aren't any breaking changes with this PR (but a hotfix release would be appreciated).