### PR TITLE
Represent times with milliseconds

### DIFF
--- a/app/web/src/utils/date.tsx
+++ b/app/web/src/utils/date.tsx
@@ -8,7 +8,7 @@ const Text = Typography.Text;
 export function adaptTime(time) {
   return time ? (
     <>
-      {moment(time).format("MMM D HH:mm:ss Z")}{" "}
+      {moment(time).format("MMM D HH:mm:ss.SSS Z")}{" "}
       <Text style={{ color: "#00BFA6" }}>
         {" "}
         - <TimeAgo date={time} />


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

Rendered times do not include milliseconds.  

### What is the new behavior (if this is a feature change)?

For more precision, rendered times will also include the milliseconds part.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No