### PR TITLE
Auto create app if not exist

### DIFF
--- a/app/bin/bootstrap.py
+++ b/app/bin/bootstrap.py
@@ -40,6 +40,7 @@ LEEK_ES_IM_DELETE_MIN_INDEX_AGE = os.environ.get("LEEK_ES_IM_DELETE_MIN_INDEX_AG
 LEEK_API_URL = os.environ.get("LEEK_API_URL", "http://0.0.0.0:5000")
 LEEK_WEB_URL = os.environ.get("LEEK_WEB_URL", "http://0.0.0.0:8000")
 LEEK_API_ENABLE_AUTH = get_bool("LEEK_API_ENABLE_AUTH", default="true")
+LEEK_CREATE_APP_IF_NOT_EXIST = get_bool("LEEK_CREATE_APP_IF_NOT_EXIST", default="false")
 
 LOGO = """
 8 8888         8 8888888888   8 8888888888   8 8888     ,88'

--- a/app/leek/api/conf/settings.py
+++ b/app/leek/api/conf/settings.py
@@ -32,3 +32,8 @@ LEEK_ENABLE_AGENT = get_bool("LEEK_ENABLE_AGENT")
 
 # Control
 LEEK_CONTROL_EXCHANGE_NAME = os.environ.get("LEEK_CONTROL_EXCHANGE_NAME", "celery")
+
+# Create app if not exist, only supported when leek auth is disabled.
+# This is useful for dev / demo environments when developers want to kickstart the stack
+# without worrying about manual interventions like creating leek app from Leek UI.
+LEEK_CREATE_APP_IF_NOT_EXIST = get_bool("LEEK_CREATE_APP_IF_NOT_EXIST", default="false")

--- a/app/leek/api/routes/events.py
+++ b/app/leek/api/routes/events.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from flask import Blueprint, request, g
 from flask_restx import Resource
@@ -10,6 +11,7 @@ from leek.api.db.events import merge_events
 from leek.api.errors import responses
 from leek.api.routes.api_v1 import api_v1
 from leek.api.db.template import get_app
+from leek.api.db import template as apps
 
 events_bp = Blueprint('events', __name__, url_prefix='/v1/events')
 events_ns = api_v1.namespace('events', 'Agents events handler')
@@ -43,14 +45,38 @@ class ProcessEvents(Resource):
         except KeyError as e:
             return responses.missing_headers
 
+        template_name = f"{org_name}-{app_name}"
+
         try:
             # Get application
-            app = get_app(f"{org_name}-{app_name}")
+            app = get_app(template_name)
             # Authenticate
             if app_key not in [app["app_key"], settings.LEEK_AGENT_API_SECRET]:
                 return responses.wrong_application_app_key
         except es_exceptions.NotFoundError:
-            return responses.application_not_found
+            # Create app if not exist, only supported when leek auth is disabled.
+            if settings.LEEK_CREATE_APP_IF_NOT_EXIST and not settings.LEEK_API_ENABLE_AUTH:
+                logger.warning("LEEK_CREATE_APP_IF_NOT_EXIST was set to true, leek app will be auto-created by agent.")
+                app = {
+                    "app_name": app_name,
+                    "app_description": "auto created app by agent",
+                    "fo_triggers": [],
+                    "owner": "public",
+                    "app_key": settings.LEEK_AGENT_API_SECRET,
+                    "created_at": int(round(time.time() * 1000))
+                }
+                _, status_code = apps.create_index_template(
+                    index_alias=template_name,
+                    number_of_shards=1,
+                    number_of_replicas=0,
+                    lifecycle_policy_name="leek-rollover-policy",
+                    meta=app
+                )
+                if status_code == 201:
+                    logger.info("leek app auto-created successfully.")
+                    return "Ready!", 200
+            else:
+                return responses.application_not_found
         except es_exceptions.ConnectionError:
             return responses.search_backend_unavailable
 

--- a/demo/docker-compose-redis-no-auth.yml
+++ b/demo/docker-compose-redis-no-auth.yml
@@ -16,6 +16,8 @@ services:
       - LEEK_ES_URL=http://es01:9200
       # Authentication
       - LEEK_API_ENABLE_AUTH=false
+      # App
+      - LEEK_CREATE_APP_IF_NOT_EXIST=true
       # Subscriptions
       - |
         LEEK_AGENT_SUBSCRIPTIONS=

--- a/demo/docker-compose-rmq-no-auth.yml
+++ b/demo/docker-compose-rmq-no-auth.yml
@@ -16,6 +16,8 @@ services:
       - LEEK_ES_URL=http://es01:9200
       # Authentication
       - LEEK_API_ENABLE_AUTH=false
+      # App
+      - LEEK_CREATE_APP_IF_NOT_EXIST=true
       # Subscriptions
       - |
         LEEK_AGENT_SUBSCRIPTIONS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,11 @@ services:
       - LEEK_API_URL=http://0.0.0.0:5000
       - LEEK_WEB_URL=http://0.0.0.0:8000
       - LEEK_ES_URL=http://es01:9200
+      - LEEK_ENABLE_DDTRACE=false
       # Authentication
       - LEEK_API_ENABLE_AUTH=false
+      # App
+      - LEEK_CREATE_APP_IF_NOT_EXIST=true
       # Subscriptions
       - |
         LEEK_AGENT_SUBSCRIPTIONS=


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

### What is the current behavior? (You can also link to an open issue here)

After starting leek, developers need to open Leek UI in browser and manually create the app to match the one in agent subscriptions. until then the agent will keep showing this warning:

```
leek-app-1        | WARNING:leek.agent.consumer:(main) b'{"error": {"code": "404001", "message": "Application does not exist", "reason": "Index not yet created, use Leek UI to create a new application"}}\n'
```

### What is the new behavior (if this is a feature change)?

Leek agent will auto-create the application if environment variable `LEEK_CREATE_APP_IF_NOT_EXIST` is set to `true`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No