### PR TITLE
Add historicalData query param to datadog url

### DIFF
--- a/app/web/src/containers/tasks/TaskDetails.tsx
+++ b/app/web/src/containers/tasks/TaskDetails.tsx
@@ -308,7 +308,7 @@ export default (props) => {
               LINK
             </Text>
             <a
-                href={`https://app.datadoghq.com/apm/traces?query=%40celery.correlation_id%3A${props.task.uuid}%20&start=${twoWeeksFromNow()}&end=${Date.now()}&paused=false`}
+                href={`https://app.datadoghq.com/apm/traces?query=%40celery.correlation_id%3A${props.task.uuid}%20&start=${twoWeeksFromNow()}&end=${Date.now()}&paused=false&historicalData=true`}
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{color: "orchid"}}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Patch

### What is the current behavior? (You can also link to an open issue here)

when opening up a linked trace in Datadog, in the URL we should set historicalData=true where it's currently set to historicalData=false

### What is the new behavior (if this is a feature change)?

Set historicalData to true

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
