### PR TITLE
keep track of only last 21 task state transitions

### DIFF
--- a/app/conf/painless/TaskMerge.groovy
+++ b/app/conf/painless/TaskMerge.groovy
@@ -137,6 +137,6 @@ if (ctx._source.parent_id != null && ctx._source.parent_id.equals(ctx._source.id
 
 // Increment events count
 ctx._source.events_count = events_count + new_events_count;
-// Keep only record of past 21 states transitions
+// Record only past 21 task states transitions
 events = [params.state] + events[0..21]
 ctx._source.events = events;

--- a/app/conf/painless/TaskMerge.groovy
+++ b/app/conf/painless/TaskMerge.groovy
@@ -137,5 +137,6 @@ if (ctx._source.parent_id != null && ctx._source.parent_id.equals(ctx._source.id
 
 // Increment events count
 ctx._source.events_count = events_count + new_events_count;
-events.add(params.state);
+// Keep only record of past 21 states transitions
+events = [params.state] + events[0..21]
 ctx._source.events = events;

--- a/app/leek/agent/models/task.py
+++ b/app/leek/agent/models/task.py
@@ -173,5 +173,6 @@ class Task(EV):
 
         # Increment events count
         self.events_count = events_count + 1
-        events.append(coming.state)
+        # Keep only record of past 21 states transitions
+        events = [coming.state, *events[0:20]]
         self.events = events

--- a/app/leek/agent/models/task.py
+++ b/app/leek/agent/models/task.py
@@ -173,6 +173,6 @@ class Task(EV):
 
         # Increment events count
         self.events_count = events_count + 1
-        # Keep only record of past 21 states transitions
+        # Record only past 21 task states transitions
         events = [coming.state, *events[0:20]]
         self.events = events


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Enhancement

### What is the current behavior? (You can also link to an open issue here)

Keep track of infinite number of state transitions which can cause indexing latency if a task is not configured with max retries.

### What is the new behavior (if this is a feature change)?

Keep track of only 21 state transitions

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
