### PR TITLE
Fix Queued/Received events merge

### DIFF
--- a/app/conf/painless/TaskMerge.groovy
+++ b/app/conf/painless/TaskMerge.groovy
@@ -62,6 +62,14 @@ else if (STATES_TERMINAL.contains(ctx._source.state)) {
 
     // Get safe attrs from coming task
     attrs_to_upsert.addAll(TaskStateFields[params.state]);
+    if (QUEUED != params.state && new_events.contains(QUEUED)) {
+        // QUEUED already merged by Agent, we should not lose its attributes when merged by Index
+        attrs_to_upsert.addAll(TaskStateFields[QUEUED]);
+    }
+    if (RECEIVED != params.state && new_events.contains(RECEIVED)) {
+        // RECEIVED already merged by Agent, we should not lose its attributes when merged by Index
+        attrs_to_upsert.addAll(TaskStateFields[RECEIVED]);
+    }
     // States with same attrs
     if (params.state == RETRY){
         if (![FAILED, CRITICAL].contains(ctx._source.state)){
@@ -71,6 +79,10 @@ else if (STATES_TERMINAL.contains(ctx._source.state)) {
     }
     else if ([QUEUED, RECEIVED].contains(params.state)) {
         // QUEUED|RECEIVED event came late, update with attrs send only by QUEUED|RECEIVED events
+        attrs_to_upsert.addAll(TaskStateFields.QUEUED_RECEIVED);
+    }
+    else if (new_events.contains(QUEUED) || new_events.contains(RECEIVED)) {
+        // QUEUED|RECEIVED already merged by Agent, we should not lose their attributes when merged by Index
         attrs_to_upsert.addAll(TaskStateFields.QUEUED_RECEIVED);
     }
     // Merge

--- a/demo/src/leek_demo/app.py
+++ b/demo/src/leek_demo/app.py
@@ -6,6 +6,7 @@ from kombu import Queue
 app = Celery('tasks', broker=os.environ['BROKER_URL'])
 
 app.conf.task_send_sent_event = True
+app.conf.task_track_started = True
 app.conf.imports = (
     "leek_demo.tasks.low",
     "leek_demo.tasks.medium",


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

### What is the current behavior? (You can also link to an open issue here)

The RECEIVED/QUEUED events attributes are lost by index merge when the STARTED event comes late and agent attribute merge it.

This causes `["name", "args", "kwargs", "root_id", "parent_id", "eta", "expires", "retries", "queued_at", "exchange", "routing_key", "queue", "client"]` to be dropped for some tasks

### What is the new behavior (if this is a feature change)?

Check if RECEIVED/QUEUED events already merged by agent and merge their attributes by Index

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
